### PR TITLE
port to NeoForge 26.1.2 / MC 26.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'team.cagayakegirls.scripts'
-	id 'dev.architectury.loom'
+	id 'dev.architectury.loom-no-remap'
 	id 'maven-publish'
 	alias(libs.plugins.modpublisher)
 }
@@ -25,16 +25,15 @@ repositories {
 dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 //	mappings "net.fabricmc:yarn:${project.mappings_version}:v2"
-    mappings loom.officialMojangMappings()
 	neoForge "net.neoforged:neoforge:${project.neoforge_version}"
 	implementation "com.google.code.findbugs:jsr305:3.0.2"
 
-	modImplementation "team.cagayakegirls.mafglib:mafglib:${project.malilib_version}"
-//	modImplementation "com.github.sakura-ryoko:malilib:${project.malilib_version}"
+	implementation "team.cagayakegirls.mafglib:mafglib:${project.malilib_version}"
+//	implementation "com.github.sakura-ryoko:malilib:${project.malilib_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
-	//modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
-	include(implementation("me.fallenbreath:conditional-mixin-fabric:${project.conditionalmixin_version}"))
+	//implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
+	implementation "me.fallenbreath:conditional-mixin-fabric:${project.conditionalmixin_version}"
 
 //	modCompileOnly "com.terraformersmc:modmenu:${project.mod_menu_version}"
 //	modCompileOnly "maven.modrinth:iris:${project.iris_version}+${project.iris_mc_version}-fabric"
@@ -97,7 +96,7 @@ tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
 
 	// Minecraft 1.20.5 (24w14a) upwards uses Java 21.
-	it.options.release = 21
+	it.options.release = 25
 }
 
 tasks.withType(AbstractArchiveTask).configureEach {
@@ -106,11 +105,11 @@ tasks.withType(AbstractArchiveTask).configureEach {
 }
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
-	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-	// if it is present.
-	// If you remove this line, sources will not be generated.
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(25)
+	}
+	sourceCompatibility = JavaVersion.VERSION_25
+	targetCompatibility = JavaVersion.VERSION_25
 	withSourcesJar()
 }
 
@@ -120,7 +119,8 @@ jar {
 	}
 }
 
-remapJar.atAccessWideners.add("litematica.accesswidener")
+// remapJar not used with loom-no-remap (unobfuscated MC)
+// remapJar.atAccessWideners.add("litematica.accesswidener")
 
 tasks.publish.dependsOn build
 publishing {
@@ -167,6 +167,6 @@ publisher {
 	setGameVersions("1.21.11")
 	setLoaders(loom.platform.get().id())
 	setCurseEnvironment("${libs.versions.version.env.get()}")
-	setArtifact(remapJar)
+	setArtifact(jar)
 	addAdditionalFile(sourcesJar)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,12 +14,12 @@ mod_file_name = forgematica
 mod_version = 0.4.2
 
 # Required malilib version
-malilib_version = 0.4.3+mc1.21.11
+malilib_version = 0.5.0+mc26.1.1
 
 # Minecraft, Fabric Loader and API and mappings versions
-minecraft_version_out = 1.21.11
-minecraft_version = 1.21.11
+minecraft_version_out = 26.1.2
+minecraft_version = 26.1.2
 
-neoforge_version = 21.11.38-beta
+neoforge_version = 26.1.2.48-beta
 # fabric_api_version = 0.140.2+1.21.11
 conditionalmixin_version = 0.6.4

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 range-fml = "[4,)"
-range-game = "[1.21.11,)"
-range-neoforge = "[21.11,)"
-range-mafglib = "[0.4,)"
+range-game = "[26.1.2,)"
+range-neoforge = "[26.1,)"
+range-mafglib = "[0.5,)"
 
 mod-link = "https://github.com/CagayakeGirls/litematica-neoforge"
 
@@ -14,9 +14,9 @@ platformId-modrinth = "dCKRaeBC"
 
 yarn-patch = "1.21+build.6"
 
-architectury-loom = "1.13-SNAPSHOT"
+architectury-loom = "1.14.473"
 modpublisher = "2.+"
 
 [plugins]
-architectury-loom = { id = "dev.architectury.loom", version.ref = "architectury-loom" }
+architectury-loom = { id = "dev.architectury.loom-no-remap", version.ref = "architectury-loom" }
 modpublisher = { id = "com.hypherionmc.modutils.modpublisher", version.ref = "modpublisher" }

--- a/src/main/java/fi/dy/masa/litematica/InitHandler.java
+++ b/src/main/java/fi/dy/masa/litematica/InitHandler.java
@@ -36,7 +36,7 @@ public class InitHandler implements IInitializationHandler
         InputEventHandler.getInputManager().registerMouseInputHandler(InputHandler.getInstance());
 
         IRenderer renderer = new RenderHandler();
-        RenderEventHandler.getInstance().registerGameOverlayRenderer(renderer);
+        RenderEventHandler.getInstance().registerInGameGuiRenderer(renderer);
         RenderEventHandler.getInstance().registerWorldPreWeatherRenderer(renderer);
         RenderEventHandler.getInstance().registerWorldLastRenderer(renderer);
 

--- a/src/main/java/fi/dy/masa/litematica/command/PmCommand.java
+++ b/src/main/java/fi/dy/masa/litematica/command/PmCommand.java
@@ -69,13 +69,13 @@ public class PmCommand implements IClientCommandListener
 
 	private boolean processInvalid(ChatComponent chat)
 	{
-		chat.addMessage(StringUtils.translateAsText(PREFIX+".invalid_other"));
+		chat.addClientSystemMessage(StringUtils.translateAsText(PREFIX+".invalid_other"));
 		return true;
 	}
 
 	private boolean processHelp(ChatComponent chat)
 	{
-		chat.addMessage(StringUtils.translateAsText(PREFIX+".help")
+		chat.addClientSystemMessage(StringUtils.translateAsText(PREFIX+".help")
 		);
 
 		return true;
@@ -97,12 +97,12 @@ public class PmCommand implements IClientCommandListener
 			}
 			catch (NumberFormatException e)
 			{
-				chat.addMessage(StringUtils.translateAsText(PREFIX+".invalid_args"));
+				chat.addClientSystemMessage(StringUtils.translateAsText(PREFIX+".invalid_args"));
 			}
 		}
 		else
 		{
-			DataManager.getSchematicPlacementManager().displayChunkDebugCmd(camPos.x, camPos.z, chat);
+			DataManager.getSchematicPlacementManager().displayChunkDebugCmd(camPos.x(), camPos.z(), chat);
 		}
 
 		return true;
@@ -124,12 +124,12 @@ public class PmCommand implements IClientCommandListener
 			}
 			catch (NumberFormatException e)
 			{
-				chat.addMessage(StringUtils.translateAsText(PREFIX+".invalid_args"));
+				chat.addClientSystemMessage(StringUtils.translateAsText(PREFIX+".invalid_args"));
 			}
 		}
 		else
 		{
-			DataManager.getSchematicPlacementManager().markChunkForRebuildCmd(camPos.x, camPos.z, chat);
+			DataManager.getSchematicPlacementManager().markChunkForRebuildCmd(camPos.x(), camPos.z(), chat);
 		}
 
 		return true;

--- a/src/main/java/fi/dy/masa/litematica/data/DataManager.java
+++ b/src/main/java/fi/dy/masa/litematica/data/DataManager.java
@@ -47,7 +47,8 @@ public class DataManager implements IDirectoryCache
     private static final ArrayList<ToBooleanFunction<Component>> CHAT_LISTENERS = new ArrayList<>();
     public static final Identifier CARPET_HELLO = Identifier.fromNamespaceAndPath("carpet", "hello");
 
-    private static ItemStack toolItem = new ItemStack(Items.STICK);
+    private static ItemStack toolItem = null;
+    private static String pendingToolItemName = null;
     private ItemStack toolItemComponents = null;
     private static ConfigGuiTab configGuiTab = ConfigGuiTab.GENERIC;
     private static boolean createPlacementOnLoad = true;
@@ -113,6 +114,21 @@ public class DataManager implements IDirectoryCache
 
     public static ItemStack getToolItem()
     {
+        if (toolItem == null)
+        {
+            String name = pendingToolItemName;
+            pendingToolItemName = null;
+
+            if (name != null)
+            {
+                toolItem = InventoryUtils.getItemStackFromString(name);
+            }
+            if (toolItem == null)
+            {
+                toolItem = new ItemStack(Items.STICK);
+                Configs.Generic.TOOL_ITEM.setValueFromString(BuiltInRegistries.ITEM.getKey(Items.STICK).toString());
+            }
+        }
         return toolItem;
     }
 
@@ -647,14 +663,10 @@ public class DataManager implements IDirectoryCache
      */
     public static void setToolItem(String itemNameIn)
     {
-        toolItem = InventoryUtils.getItemStackFromString(itemNameIn);
-
-        if (toolItem == null)
-        {
-            // Fall back to a stick
-            toolItem = new ItemStack(Items.STICK);
-            Configs.Generic.TOOL_ITEM.setValueFromString(BuiltInRegistries.ITEM.getKey(Items.STICK).toString());
-        }
+        // Defer ItemStack creation until registries have their components bound.
+        // getToolItem() will resolve it lazily on first access.
+        pendingToolItemName = itemNameIn;
+        toolItem = null;
     }
 
     /**

--- a/src/main/java/fi/dy/masa/litematica/data/EntitiesDataStorage.java
+++ b/src/main/java/fi/dy/masa/litematica/data/EntitiesDataStorage.java
@@ -1051,7 +1051,7 @@ public class EntitiesDataStorage implements IClientTickHandler, IDataSyncer
         maxY = Mth.clamp(maxY, -60, 319);
 
         ClientLevel world = this.getClientWorld();
-        ChunkAccess chunk = world != null ? world.getChunk(chunkPos.x, chunkPos.z, ChunkStatus.FULL, false) : null;
+        ChunkAccess chunk = world != null ? world.getChunk(chunkPos.x(), chunkPos.z(), ChunkStatus.FULL, false) : null;
 
         if (chunk == null)
         {
@@ -1195,11 +1195,11 @@ public class EntitiesDataStorage implements IClientTickHandler, IDataSyncer
 
         BlockEntity blockEntity = this.getClientWorld().getBlockEntity(pos);
 
-        if (blockEntity != null && (type == null || type.equals(BlockEntityType.getKey(blockEntity.getType()))))
+        if (blockEntity != null && (type == null || type.equals(BuiltInRegistries.BLOCK_ENTITY_TYPE.getKey(blockEntity.getType()))))
         {
             if (data.contains(NbtKeys.ID, Constants.NBT.TAG_STRING) == false)
             {
-                Identifier id = BlockEntityType.getKey(blockEntity.getType());
+                Identifier id = BuiltInRegistries.BLOCK_ENTITY_TYPE.getKey(blockEntity.getType());
 
                 if (id != null)
                 {
@@ -1214,7 +1214,7 @@ public class EntitiesDataStorage implements IClientTickHandler, IDataSyncer
 
             NbtView view = NbtView.getReader(data, this.getClientWorld().registryAccess());
             blockEntity.loadWithComponents(view.getReader());
-            ChunkPos chunkPos = new ChunkPos(pos);
+            ChunkPos chunkPos = ChunkPos.containing(pos);
 
             if (this.hasPendingChunk(chunkPos) && this.hasServuxServer() == false)
             {
@@ -1238,7 +1238,7 @@ public class EntitiesDataStorage implements IClientTickHandler, IDataSyncer
                 {
                     if (data.contains(NbtKeys.ID, Constants.NBT.TAG_STRING) == false)
                     {
-                        Identifier id = BlockEntityType.getKey(beType);
+                        Identifier id = BuiltInRegistries.BLOCK_ENTITY_TYPE.getKey(beType);
 
                         if (id != null)
                         {
@@ -1257,7 +1257,7 @@ public class EntitiesDataStorage implements IClientTickHandler, IDataSyncer
                         this.getClientWorld().setBlockEntity(blockEntity2);
                     }
 
-                    ChunkPos chunkPos = new ChunkPos(pos);
+                    ChunkPos chunkPos = ChunkPos.containing(pos);
 
                     if (this.hasPendingChunk(chunkPos) && this.hasServuxServer() == false)
                     {
@@ -1406,7 +1406,7 @@ public class EntitiesDataStorage implements IClientTickHandler, IDataSyncer
             long now = Util.getMillis();
 
             // Take no action when ChunkPos is not loaded by the ClientWorld.
-            if (WorldUtils.isClientChunkLoaded(this.mc.level, pos.x, pos.z) == false)
+            if (WorldUtils.isClientChunkLoaded(this.mc.level, pos.x(), pos.z()) == false)
             {
                 this.pendingChunkTimeout.replace(pos, now);
                 return;

--- a/src/main/java/fi/dy/masa/litematica/event/RenderHandler.java
+++ b/src/main/java/fi/dy/masa/litematica/event/RenderHandler.java
@@ -1,12 +1,16 @@
 package fi.dy.masa.litematica.event;
 
 import java.util.function.Supplier;
-import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderBuffers;
 import net.minecraft.client.renderer.culling.Frustum;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.util.profiling.ProfilerFiller;
 import org.joml.Matrix4f;
+import org.joml.Matrix4fc;
+import org.joml.Vector4f;
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
+import com.mojang.blaze3d.pipeline.RenderTarget;
 import fi.dy.masa.malilib.interfaces.IRenderer;
 import fi.dy.masa.malilib.render.GuiContext;
 import fi.dy.masa.malilib.util.GuiUtils;
@@ -34,30 +38,32 @@ public class RenderHandler implements IRenderer
 //    }
 
     @Override
-    public void onRenderWorldLastAdvanced(RenderTarget fb, Matrix4f posMatrix, Matrix4f projMatrix, Frustum frustum, Camera camera, RenderBuffers buffers, ProfilerFiller profiler)
+    public void onRenderWorldLast(RenderTarget fb, Matrix4fc posMatrix, CameraRenderState cameraRenderState, Frustum frustum, RenderBuffers buffers, GpuBufferSlice slice, Vector4f vec4f, ProfilerFiller profiler)
     {
         Minecraft mc = Minecraft.getInstance();
 
         if (Configs.Visuals.ENABLE_RENDERING.getBooleanValue() && mc.player != null)
         {
+            Matrix4f pos = (Matrix4f) posMatrix;
+            Matrix4f proj = cameraRenderState.projectionMatrix;
             profiler.push("overlay_boxes");
-            OverlayRenderer.getInstance().renderBoxes(posMatrix, projMatrix, profiler);
+            OverlayRenderer.getInstance().renderBoxes(pos, proj, profiler);
 
             if (Configs.InfoOverlays.VERIFIER_OVERLAY_ENABLED.getBooleanValue())
             {
                 profiler.popPush("overlay_mismatches");
-                OverlayRenderer.getInstance().renderSchematicVerifierMismatches(posMatrix, projMatrix, profiler);
+                OverlayRenderer.getInstance().renderSchematicVerifierMismatches(pos, proj, profiler);
             }
 
             if (DataManager.getToolMode() == ToolMode.REBUILD)
             {
                 profiler.popPush("overlay_targeting");
-                OverlayRenderer.getInstance().renderSchematicRebuildTargetingOverlay(posMatrix, projMatrix, profiler);
+                OverlayRenderer.getInstance().renderSchematicRebuildTargetingOverlay(pos, proj, profiler);
             }
 
             // Schematic Overlay Rendering
             profiler.popPush("schematic_overlay");
-            LitematicaRenderer.getInstance().piecewiseRenderOverlay(posMatrix, projMatrix, profiler);
+            LitematicaRenderer.getInstance().piecewiseRenderOverlay(pos, proj, profiler);
             profiler.pop();
         }
     }
@@ -69,7 +75,7 @@ public class RenderHandler implements IRenderer
     }
 
     @Override
-    public void onRenderGameOverlayPostAdvanced(GuiContext ctx, float partialTicks, ProfilerFiller profiler)
+    public void onExtractGuiOverlayPost(GuiContext ctx, float partialTicks, ProfilerFiller profiler)
     {
         if (Configs.Visuals.ENABLE_RENDERING.getBooleanValue() && ctx.mc().player != null)
         {

--- a/src/main/java/fi/dy/masa/litematica/gui/widgets/WidgetSchematicVerificationResult.java
+++ b/src/main/java/fi/dy/masa/litematica/gui/widgets/WidgetSchematicVerificationResult.java
@@ -567,9 +567,9 @@ public class WidgetSchematicVerificationResult extends WidgetListEntrySortable<B
 //
 ////            DiffuseLighting.enableGuiDepthLighting();
 //
-//        List<BlockModelPart> parts = model.getParts(RAND);
+//        List<BlockStateModelPart> parts = model.getParts(RAND);
 //
-//        for (BlockModelPart part : parts)
+//        for (BlockStateModelPart part : parts)
 //        {
 //            for (Direction face : PositionUtils.ALL_DIRECTIONS)
 //            {

--- a/src/main/java/fi/dy/masa/litematica/materials/MaterialListHudRenderer.java
+++ b/src/main/java/fi/dy/masa/litematica/materials/MaterialListHudRenderer.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.inventory.Slot;
@@ -75,7 +75,7 @@ public class MaterialListHudRenderer implements IInfoHudRenderer
     }
 
     @Override
-    public int render(GuiGraphics drawContext, int xOffset, int yOffset, HudAlignment alignment)
+    public int render(GuiGraphicsExtractor drawContext, int xOffset, int yOffset, HudAlignment alignment)
     {
         Minecraft mc = Minecraft.getInstance();
         long currentTime = System.currentTimeMillis();

--- a/src/main/java/fi/dy/masa/litematica/materials/MaterialListJsonExporter.java
+++ b/src/main/java/fi/dy/masa/litematica/materials/MaterialListJsonExporter.java
@@ -84,7 +84,7 @@ public class MaterialListJsonExporter
 					int mismatched = entry.getCountMismatched() * mul;
 					int available = entry.getCountAvailable();
 
-					this.putEntry(new Entry(entry.getStack().getItemHolder(), total, missing, mismatched, available));
+					this.putEntry(new Entry(entry.getStack().typeHolder(), total, missing, mismatched, available));
 				}
 		);
 

--- a/src/main/java/fi/dy/masa/litematica/materials/json/MaterialListJson.java
+++ b/src/main/java/fi/dy/masa/litematica/materials/json/MaterialListJson.java
@@ -51,7 +51,7 @@ public class MaterialListJson
         materials.forEach(
                 (entry) ->
                 {
-                    Holder<Item> resultItem = entry.getStack().getItemHolder();
+                    Holder<Item> resultItem = entry.getStack().typeHolder();
                     final int total = (entry.getStack().getCount() * entry.getCountTotal());
                     MaterialListJsonBase base = new MaterialListJsonBase(resultItem, total, null, craftingOnly);
 
@@ -80,7 +80,7 @@ public class MaterialListJson
         materials.forEach(
                 (entry) ->
                 {
-                    Holder<Item> resultItem = entry.getStack().getItemHolder();
+                    Holder<Item> resultItem = entry.getStack().typeHolder();
                     final int total = (entry.getStack().getCount() * entry.getCountTotal());
                     MaterialListJsonBase base = new MaterialListJsonBase(resultItem, total, null, craftingOnly);
 

--- a/src/main/java/fi/dy/masa/litematica/materials/json/MaterialListJsonEntry.java
+++ b/src/main/java/fi/dy/masa/litematica/materials/json/MaterialListJsonEntry.java
@@ -175,7 +175,7 @@ public class MaterialListJsonEntry
                 SlotDisplay display = ing.display();
                 List<ItemStack> displayStacks = display.resolveForStacks(map);
                 ItemStack displayStack = displayStacks.getFirst();
-                Holder<Item> itemEntry = displayStack.getItemHolder();
+                Holder<Item> itemEntry = displayStack.typeHolder();
                 HolderSet<Item> ingEntries = ((IMixinIngredient) (Object) ing).malilib_getEntries();
 
                 if (ingEntries.size() > 1)

--- a/src/main/java/fi/dy/masa/litematica/mixin/client/MixinMinecraft.java
+++ b/src/main/java/fi/dy/masa/litematica/mixin/client/MixinMinecraft.java
@@ -15,7 +15,7 @@ public abstract class MixinMinecraft extends ReentrantBlockableEventLoop<Runnabl
 {
     public MixinMinecraft(String string_1)
     {
-        super(string_1);
+        super(string_1, false);
     }
 
     @Inject(method = "tick()V", at = @At("HEAD"))

--- a/src/main/java/fi/dy/masa/litematica/mixin/hud/MixinDebugScreenOverlay.java
+++ b/src/main/java/fi/dy/masa/litematica/mixin/hud/MixinDebugScreenOverlay.java
@@ -23,7 +23,7 @@ public abstract class MixinDebugScreenOverlay
 {
 	@Shadow @Final private Minecraft minecraft;
 
-	@WrapOperation(method = "render(Lnet/minecraft/client/gui/GuiGraphics;)V",
+	@WrapOperation(method = "extractRenderState(Lnet/minecraft/client/gui/GuiGraphicsExtractor;)V",
 	               at = @At(value = "INVOKE",
 					   target = "Ljava/util/Collection;isEmpty()Z",
 					   ordinal = 0))
@@ -37,9 +37,9 @@ public abstract class MixinDebugScreenOverlay
 		return instance.isEmpty();
 	}
 
-	@ModifyArg(method = "render(Lnet/minecraft/client/gui/GuiGraphics;)V",
+	@ModifyArg(method = "extractRenderState(Lnet/minecraft/client/gui/GuiGraphicsExtractor;)V",
 			   at = @At(value = "INVOKE",
-					 target = "Lnet/minecraft/client/gui/components/DebugScreenOverlay;renderLines(Lnet/minecraft/client/gui/GuiGraphics;Ljava/util/List;Z)V",
+					 target = "Lnet/minecraft/client/gui/components/DebugScreenOverlay;extractLines(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Ljava/util/List;Z)V",
 						ordinal = 0),
 			   index = 1)
 	private List<String> litematica_addDebugLines_Left(List<String> text)

--- a/src/main/java/fi/dy/masa/litematica/mixin/network/MixinClientPacketListener.java
+++ b/src/main/java/fi/dy/masa/litematica/mixin/network/MixinClientPacketListener.java
@@ -42,7 +42,7 @@ public abstract class MixinClientPacketListener
         if (Configs.Generic.LOAD_ENTIRE_SCHEMATICS.getBooleanValue() == false)
         {
             //Litematica.debugLog("MixinClientPlayNetworkHandler#litematica_onChunkUnload({}, {})", packet.pos().x, packet.pos().z);
-            DataManager.getSchematicPlacementManager().onClientChunkUnload(packet.pos().x, packet.pos().z);
+            DataManager.getSchematicPlacementManager().onClientChunkUnload(packet.pos().x(), packet.pos().z());
         }
     }
 

--- a/src/main/java/fi/dy/masa/litematica/mixin/render/IMixinBlockRenderManager.java
+++ b/src/main/java/fi/dy/masa/litematica/mixin/render/IMixinBlockRenderManager.java
@@ -1,13 +1,10 @@
 package fi.dy.masa.litematica.mixin.render;
 
-import net.minecraft.client.renderer.block.BlockRenderDispatcher;
-import net.minecraft.client.renderer.block.LiquidBlockRenderer;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelDispatcher;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.gen.Accessor;
 
-@Mixin(BlockRenderDispatcher.class)
+@Mixin(BlockStateModelDispatcher.class)
 public interface IMixinBlockRenderManager
 {
-	@Accessor("liquidBlockRenderer")
-	LiquidBlockRenderer litematica_getFluidRenderer();
+    // liquidBlockRenderer no longer exists on BlockStateModelDispatcher in 26.1.x
 }

--- a/src/main/java/fi/dy/masa/litematica/mixin/render/MixinBlockRenderDispatcher.java
+++ b/src/main/java/fi/dy/masa/litematica/mixin/render/MixinBlockRenderDispatcher.java
@@ -1,20 +1,11 @@
 package fi.dy.masa.litematica.mixin.render;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelDispatcher;
 
-import fi.dy.masa.litematica.render.LitematicaRenderer;
-import net.minecraft.client.renderer.block.BlockRenderDispatcher;
-import net.minecraft.server.packs.resources.ResourceManager;
-
-@Mixin(BlockRenderDispatcher.class)
+// onResourceManagerReload no longer exists on BlockStateModelDispatcher in 26.1.x;
+// FluidRenderer is now created on-demand from ModelManager.getFluidStateModelSet()
+@Mixin(BlockStateModelDispatcher.class)
 public class MixinBlockRenderDispatcher
 {
-	@Inject(method = "onResourceManagerReload", at = @At("TAIL"))
-	private void litematica_onBlockRenderManagerReload(ResourceManager manager, CallbackInfo ci)
-	{
-		LitematicaRenderer.getInstance().onBlockModelRendererReload((BlockRenderDispatcher) (Object) this);
-	}
 }

--- a/src/main/java/fi/dy/masa/litematica/mixin/render/MixinGameRenderer.java
+++ b/src/main/java/fi/dy/masa/litematica/mixin/render/MixinGameRenderer.java
@@ -1,6 +1,7 @@
 package fi.dy.masa.litematica.mixin.render;
 
 import net.minecraft.client.Camera;
+import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.renderer.GameRenderer;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -17,8 +18,8 @@ public class MixinGameRenderer
 	@Shadow @Final private Camera mainCamera;
 
 	@Inject(method = "extractCamera", at = @At("TAIL"))
-	private void litematica_updateCameraState(float f, CallbackInfo ci)
+	private void litematica_updateCameraState(DeltaTracker deltaTracker, float f1, float f2, CallbackInfo ci)
 	{
-		LitematicaRenderer.getInstance().updateCameraState(this.mainCamera, f);
+		LitematicaRenderer.getInstance().updateCameraState(this.mainCamera, f1);
 	}
 }

--- a/src/main/java/fi/dy/masa/litematica/mixin/render/MixinWorldRenderer.java
+++ b/src/main/java/fi/dy/masa/litematica/mixin/render/MixinWorldRenderer.java
@@ -21,7 +21,8 @@ import net.minecraft.client.renderer.SubmitNodeStorage;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayerGroup;
 import net.minecraft.client.renderer.chunk.ChunkSectionsToRender;
 import net.minecraft.client.renderer.culling.Frustum;
-import net.minecraft.client.renderer.state.LevelRenderState;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
+import net.minecraft.client.renderer.state.level.LevelRenderState;
 import net.minecraft.util.profiling.ActiveProfiler;
 import net.minecraft.util.profiling.Profiler;
 import net.minecraft.util.profiling.ProfilerFiller;
@@ -46,8 +47,8 @@ public abstract class MixinWorldRenderer
     @Shadow private net.minecraft.client.multiplayer.ClientLevel level;
     @Shadow @Final private Minecraft minecraft;
 	@Shadow @Final private SubmitNodeStorage submitNodeStorage;
-    @Shadow private @Nullable Frustum capturedFrustum;
 	@Shadow private @Nullable GpuSampler chunkLayerSampler;
+	@Unique private @Nullable Frustum litematica$capturedFrustum;
 	@Unique private ProfilerFiller profiler;
 
     @Unique
@@ -80,6 +81,7 @@ public abstract class MixinWorldRenderer
     private void litematica_onPostSetupTerrain(
             Camera camera, Frustum frustum, boolean bl, CallbackInfo ci)
     {
+        this.litematica$capturedFrustum = frustum;
         this.litematica$prepareProfiler();
         LitematicaRenderer.getInstance().piecewisePrepare(frustum, this.profiler);
     }
@@ -113,61 +115,58 @@ public abstract class MixinWorldRenderer
 
     @Inject(method = "renderLevel",
             at = @At(value = "INVOKE",
-                    target = "Lnet/minecraft/client/renderer/LevelRenderer;addMainPass(Lcom/mojang/blaze3d/framegraph/FrameGraphBuilder;Lnet/minecraft/client/renderer/culling/Frustum;Lorg/joml/Matrix4f;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;ZLnet/minecraft/client/renderer/state/LevelRenderState;Lnet/minecraft/client/DeltaTracker;Lnet/minecraft/util/profiling/ProfilerFiller;)V",
+                    target = "Lnet/minecraft/client/renderer/LevelRenderer;addMainPass(Lcom/mojang/blaze3d/framegraph/FrameGraphBuilder;Lnet/minecraft/client/renderer/culling/Frustum;Lorg/joml/Matrix4fc;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;ZLnet/minecraft/client/renderer/state/level/LevelRenderState;Lnet/minecraft/client/DeltaTracker;Lnet/minecraft/util/profiling/ProfilerFiller;Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;)V",
                     shift = At.Shift.BEFORE))
     private void litematica_onPreRenderMain(GraphicsResourceAllocator allocator, DeltaTracker tickCounter,
-                                            boolean renderBlockOutline, Camera camera, Matrix4f matrix4f,
-                                            Matrix4f projectionMatrix, Matrix4f matrix4f2,
+                                            boolean renderBlockOutline, CameraRenderState cameraRenderState,
+                                            Matrix4fc matrix4fc,
                                             GpuBufferSlice gpuBufferSlice, Vector4f vector4f, boolean bl,
+                                            ChunkSectionsToRender sectionsToRender,
                                             CallbackInfo ci, @Local ProfilerFiller profiler)
     {
         this.profiler = profiler;
+        Camera camera = this.minecraft.gameRenderer.getMainCamera();
         LitematicaRenderer.getInstance().capturePreMainValues(camera, gpuBufferSlice, profiler);
     }
 
     @Inject(method = "prepareChunkRenders", at = @At("TAIL"))
-    private void litematica_onPrepareBlockLayers(Matrix4fc matrix4fc, double d, double e, double f, CallbackInfoReturnable<ChunkSectionsToRender> cir)
+    private void litematica_onPrepareBlockLayers(Matrix4fc matrix4fc, CallbackInfoReturnable<ChunkSectionsToRender> cir)
     {
         this.litematica$prepareProfiler();
-        LitematicaRenderer.getInstance().piecewisePrepareBlockLayers(matrix4fc, d, e, f, this.profiler);
+        Vec3 camPos = this.minecraft.gameRenderer.getMainCamera().position();
+        LitematicaRenderer.getInstance().piecewisePrepareBlockLayers(matrix4fc, camPos.x, camPos.y, camPos.z, this.profiler);
     }
 
-	// BYTECODE (Virtual Method) Mixin for Section Group rendering
-	@Inject(method = "method_62214(Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lnet/minecraft/client/renderer/state/LevelRenderState;Lnet/minecraft/util/profiling/ProfilerFiller;Lorg/joml/Matrix4f;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;ZLcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;)V",
+	// BYTECODE (Lambda Method) Mixin for Section Group rendering — lambda$addMainPass$0 in NeoForge-patched MC 26.1.2
+	@Inject(method = "lambda$addMainPass$0(Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lnet/minecraft/client/renderer/state/level/LevelRenderState;Lnet/minecraft/util/profiling/ProfilerFiller;Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;Lorg/joml/Matrix4fc;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;Z)V",
 	        at = @At(value = "INVOKE",
 	                 target = "Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;renderGroup(Lnet/minecraft/client/renderer/chunk/ChunkSectionLayerGroup;Lcom/mojang/blaze3d/textures/GpuSampler;)V",
 	                 ordinal = 0,
 	                 shift = At.Shift.AFTER))
 	private void litematica_renderMainSection_Opaque(GpuBufferSlice gpuBufferSlice, LevelRenderState worldRenderState, ProfilerFiller profiler,
-	                                                 Matrix4f matrix4f, ResourceHandle<RenderTarget> handle, ResourceHandle<RenderTarget> handle2, boolean bl,
-	                                                 ResourceHandle<RenderTarget> handle3, ResourceHandle<RenderTarget> handle4, CallbackInfo ci)
+	                                                 ChunkSectionsToRender sectionsToRender, Matrix4fc matrix4fc,
+	                                                 ResourceHandle<RenderTarget> handle, ResourceHandle<RenderTarget> handle2,
+	                                                 ResourceHandle<RenderTarget> handle3, ResourceHandle<RenderTarget> handle4, ResourceHandle<RenderTarget> handle5,
+	                                                 boolean bl, CallbackInfo ci)
 	{
 		LitematicaRenderer.getInstance().piecewiseDrawBlockLayerGroup(ChunkSectionLayerGroup.OPAQUE, this.chunkLayerSampler);
 	}
 
-	@Inject(method = "method_62214(Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lnet/minecraft/client/renderer/state/LevelRenderState;Lnet/minecraft/util/profiling/ProfilerFiller;Lorg/joml/Matrix4f;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;ZLcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;)V",
+	@Inject(method = "lambda$addMainPass$0(Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lnet/minecraft/client/renderer/state/level/LevelRenderState;Lnet/minecraft/util/profiling/ProfilerFiller;Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;Lorg/joml/Matrix4fc;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;Z)V",
 			at = @At(value = "INVOKE",
 					 target = "Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;renderGroup(Lnet/minecraft/client/renderer/chunk/ChunkSectionLayerGroup;Lcom/mojang/blaze3d/textures/GpuSampler;)V",
 					 ordinal = 1,
 					 shift = At.Shift.AFTER))
 	private void litematica_renderMainSection_Translucent(GpuBufferSlice gpuBufferSlice, LevelRenderState worldRenderState, ProfilerFiller profiler,
-	                                                      Matrix4f matrix4f, ResourceHandle<RenderTarget> handle, ResourceHandle<RenderTarget> handle2, boolean bl,
-	                                                      ResourceHandle<RenderTarget> handle3, ResourceHandle<RenderTarget> handle4, CallbackInfo ci)
+	                                                      ChunkSectionsToRender sectionsToRender, Matrix4fc matrix4fc,
+	                                                      ResourceHandle<RenderTarget> handle, ResourceHandle<RenderTarget> handle2,
+	                                                      ResourceHandle<RenderTarget> handle3, ResourceHandle<RenderTarget> handle4, ResourceHandle<RenderTarget> handle5,
+	                                                      boolean bl, CallbackInfo ci)
 	{
 		LitematicaRenderer.getInstance().piecewiseDrawBlockLayerGroup(ChunkSectionLayerGroup.TRANSLUCENT, this.chunkLayerSampler);
 	}
 
-	@Inject(method = "method_62214(Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lnet/minecraft/client/renderer/state/LevelRenderState;Lnet/minecraft/util/profiling/ProfilerFiller;Lorg/joml/Matrix4f;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;ZLcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;)V",
-			at = @At(value = "INVOKE",
-					 target = "Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;renderGroup(Lnet/minecraft/client/renderer/chunk/ChunkSectionLayerGroup;Lcom/mojang/blaze3d/textures/GpuSampler;)V",
-					 ordinal = 2,
-					 shift = At.Shift.AFTER))
-	private void litematica_renderMainSection_Tripwire(GpuBufferSlice gpuBufferSlice, LevelRenderState worldRenderState, ProfilerFiller profiler,
-	                                                   Matrix4f matrix4f, ResourceHandle<RenderTarget> handle, ResourceHandle<RenderTarget> handle2, boolean bl,
-	                                                   ResourceHandle<RenderTarget> handle3, ResourceHandle<RenderTarget> handle4, CallbackInfo ci)
-	{
-		LitematicaRenderer.getInstance().piecewiseDrawBlockLayerGroup(ChunkSectionLayerGroup.TRIPWIRE, this.chunkLayerSampler);
-	}
+	// TRIPWIRE layer removed in 26.1.x — ChunkSectionLayerGroup only has OPAQUE and TRANSLUCENT
 
 	@Inject(method = "extractVisibleEntities", at = @At(value = "RETURN"))
     private void litematica_onPostPrepareEntities(Camera camera, Frustum frustum, DeltaTracker tickCounter,
@@ -199,7 +198,7 @@ public abstract class MixinWorldRenderer
 		if (!IrisCompat.hasSodium())
 		{
 			this.litematica$prepareProfiler();
-			LitematicaRenderer.getInstance().piecewisePrepareBlockEntities(camera, this.capturedFrustum, renderStates, tickProgress, this.profiler);
+			LitematicaRenderer.getInstance().piecewisePrepareBlockEntities(camera, this.litematica$capturedFrustum, renderStates, tickProgress, this.profiler);
 		}
     }
 

--- a/src/main/java/fi/dy/masa/litematica/mixin/screen/MixinAbstractContainerScreen.java
+++ b/src/main/java/fi/dy/masa/litematica/mixin/screen/MixinAbstractContainerScreen.java
@@ -7,7 +7,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import fi.dy.masa.litematica.materials.MaterialListHudRenderer;
 import fi.dy.masa.malilib.render.GuiContext;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.network.chat.Component;
@@ -20,15 +20,14 @@ public abstract class MixinAbstractContainerScreen extends Screen
         super(title);
     }
 
-    @Inject(method = "renderContents", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/client/gui/screens/Screen;render(Lnet/minecraft/client/gui/GuiGraphics;IIF)V"))
-    private void litematica_renderSlotHighlightsPre(GuiGraphics drawContext, int mouseX, int mouseY, float delta, CallbackInfo ci)
+    @Inject(method = "extractContents", at = @At("HEAD"))
+    private void litematica_renderSlotHighlightsPre(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta, CallbackInfo ci)
     {
         MaterialListHudRenderer.renderLookedAtBlockInInventory(GuiContext.fromGuiGraphics(drawContext), (AbstractContainerScreen<?>) (Object) this, this.minecraft);
     }
 
-    @Inject(method = "render", at = @At("TAIL"))
-    private void litematica_renderSlotHighlightsPost(GuiGraphics drawContext, int mouseX, int mouseY, float delta, CallbackInfo ci)
+    @Inject(method = "extractRenderState", at = @At("TAIL"))
+    private void litematica_renderSlotHighlightsPost(GuiGraphicsExtractor drawContext, int mouseX, int mouseY, float delta, CallbackInfo ci)
     {
         MaterialListHudRenderer.renderLookedAtBlockInInventory(GuiContext.fromGuiGraphics(drawContext), (AbstractContainerScreen<?>) (Object) this, this.minecraft);
     }

--- a/src/main/java/fi/dy/masa/litematica/render/IWorldSchematicRenderer.java
+++ b/src/main/java/fi/dy/masa/litematica/render/IWorldSchematicRenderer.java
@@ -11,22 +11,21 @@ import com.mojang.blaze3d.vertex.BufferBuilder;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Camera;
 import net.minecraft.client.DeltaTracker;
-import net.minecraft.client.renderer.LightTexture;
+import net.minecraft.util.LightCoordsUtil;
 import net.minecraft.client.renderer.SubmitNodeCollector;
-import net.minecraft.client.renderer.block.BlockRenderDispatcher;
-import net.minecraft.client.renderer.block.model.BlockModelPart;
-import net.minecraft.client.renderer.block.model.BlockStateModel;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelDispatcher;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayerGroup;
 import net.minecraft.client.renderer.culling.Frustum;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
-import net.minecraft.client.renderer.state.LevelRenderState;
+import net.minecraft.client.renderer.state.level.LevelRenderState;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.util.Brightness;
 import net.minecraft.util.RandomSource;
 import net.minecraft.util.profiling.ProfilerFiller;
-import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -69,7 +68,7 @@ public interface IWorldSchematicRenderer
 
 	void loadRenderers(@Nullable ProfilerFiller profiler);
 
-	void reloadBlockRenderManager(BlockRenderDispatcher dispatcher);
+	void reloadBlockRenderManager(BlockStateModelDispatcher dispatcher);
 
 	ChunkFixUniform getChunkFixUniform();
 
@@ -85,13 +84,13 @@ public interface IWorldSchematicRenderer
 
 	<T extends Comparable<T>> BlockState getFallbackState(BlockState origState);
 
-	boolean hasQuadsForModel(List<BlockModelPart> modelParts, BlockState state, @Nullable Direction side);
+	boolean hasQuadsForModel(List<BlockStateModelPart> modelParts, BlockState state, @Nullable Direction side);
 
-	boolean hasQuadsForModelPart(BlockModelPart modelPart, BlockState state, @Nullable Direction side);
+	boolean hasQuadsForModelPart(BlockStateModelPart modelPart, BlockState state, @Nullable Direction side);
 
 	BlockStateModel getModelForState(BlockState state);
 
-	List<BlockModelPart> getModelParts(BlockPos pos, BlockState state, RandomSource rand);
+	List<BlockStateModelPart> getModelParts(BlockPos pos, BlockState state, RandomSource rand);
 
 	boolean renderBlock(BlockAndTintGetter world, BlockState state, BlockPos pos, PoseStack matrices, BufferBuilder bufferBuilderIn);
 
@@ -138,12 +137,12 @@ public interface IWorldSchematicRenderer
 		}
 
 		int light = getter.packedLight(world, pos);
-		int blockLight = LightTexture.block(light);
+		int blockLight = LightCoordsUtil.block(light);
 		int luminance = state.getLightEmission();
 
 		if (blockLight < luminance)
 		{
-			return LightTexture.pack(luminance, LightTexture.sky(light));
+			return LightCoordsUtil.pack(luminance, LightCoordsUtil.sky(light));
 		}
 
 		return light;
@@ -153,7 +152,7 @@ public interface IWorldSchematicRenderer
 	interface LightGetter
 	{
 		LightGetter DEFAULT = (world, pos) ->
-				Brightness.pack(world.getBrightness(LightLayer.BLOCK, pos), world.getBrightness(LightLayer.SKY, pos));
+				LightCoordsUtil.pack(world.getBrightness(LightLayer.BLOCK, pos), world.getBrightness(LightLayer.SKY, pos));
 
 		int packedLight(BlockAndTintGetter world, BlockPos pos);
 	}

--- a/src/main/java/fi/dy/masa/litematica/render/LitematicaRenderer.java
+++ b/src/main/java/fi/dy/masa/litematica/render/LitematicaRenderer.java
@@ -12,10 +12,10 @@ import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.SubmitNodeStorage;
-import net.minecraft.client.renderer.block.BlockRenderDispatcher;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelDispatcher;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayerGroup;
 import net.minecraft.client.renderer.culling.Frustum;
-import net.minecraft.client.renderer.state.LevelRenderState;
+import net.minecraft.client.renderer.state.level.LevelRenderState;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.phys.Vec3;
 
@@ -83,7 +83,7 @@ public class LitematicaRenderer
         this.getWorldRenderer().setWorldAndLoadRenderers(worldClient);
     }
 
-	public void onBlockModelRendererReload(BlockRenderDispatcher manager)
+	public void onBlockModelRendererReload(BlockStateModelDispatcher manager)
 	{
 		if (this.worldRenderer != null)
 		{

--- a/src/main/java/fi/dy/masa/litematica/render/OverlayRenderer.java
+++ b/src/main/java/fi/dy/masa/litematica/render/OverlayRenderer.java
@@ -161,7 +161,7 @@ public class OverlayRenderer
                     if (currentSelection.isOriginSelected())
                     {
                         Color4f colorTmp = Color4f.fromColor(this.colorAreaOrigin, 0.4f);
-                        fi.dy.masa.malilib.render.RenderUtils.renderAreaSides(origin, origin, colorTmp, posMatrix);
+                        fi.dy.masa.malilib.render.RenderUtils.renderAreaSides(origin, origin, colorTmp);
                     }
 
                     profiler.popPush("block_outlines");
@@ -211,7 +211,7 @@ public class OverlayRenderer
                             {
                                 float alpha = (float) Configs.Visuals.PLACEMENT_BOX_SIDE_ALPHA.getDoubleValue();
                                 color = new Color4f(color.r, color.g, color.b, alpha);
-                                fi.dy.masa.malilib.render.RenderUtils.renderAreaSides(box.getPos1(), box.getPos2(), color, posMatrix);
+                                fi.dy.masa.malilib.render.RenderUtils.renderAreaSides(box.getPos1(), box.getPos2(), color);
                             }
                         }
                     }
@@ -316,18 +316,18 @@ public class OverlayRenderer
                      ((boxType == BoxType.PLACEMENT_SELECTED || boxType == BoxType.PLACEMENT_UNSELECTED) &&
                        Configs.Visuals.RENDER_PLACEMENT_BOX_SIDES.getBooleanValue()))
                 {
-                    fi.dy.masa.malilib.render.RenderUtils.renderAreaSides(pos1, pos2, sideColor, matrix4f);
+                    fi.dy.masa.malilib.render.RenderUtils.renderAreaSides(pos1, pos2, sideColor);
                 }
 
                 if (box.getSelectedCorner() == Corner.CORNER_1)
                 {
                     Color4f color = Color4f.fromColor(this.colorPos1, 0.4f);
-                    fi.dy.masa.malilib.render.RenderUtils.renderAreaSides(pos1, pos1, color, matrix4f);
+                    fi.dy.masa.malilib.render.RenderUtils.renderAreaSides(pos1, pos1, color);
                 }
                 else if (box.getSelectedCorner() == Corner.CORNER_2)
                 {
                     Color4f color = Color4f.fromColor(this.colorPos2, 0.4f);
-                    fi.dy.masa.malilib.render.RenderUtils.renderAreaSides(pos2, pos2, color, matrix4f);
+                    fi.dy.masa.malilib.render.RenderUtils.renderAreaSides(pos2, pos2, color);
                 }
 
                 fi.dy.masa.malilib.render.RenderUtils.renderBlockOutline(pos1, expand, lineWidthBlockBox, color1, false);
@@ -335,7 +335,7 @@ public class OverlayRenderer
             }
             else
             {
-                fi.dy.masa.malilib.render.RenderUtils.renderBlockOutlineOverlapping(pos1, expand, lineWidthBlockBox, color1, color2, this.colorOverlapping, matrix4f, false);
+                fi.dy.masa.malilib.render.RenderUtils.renderBlockOutlineOverlapping(pos1, expand, lineWidthBlockBox, color1, color2, this.colorOverlapping, false);
             }
         }
         else
@@ -787,12 +787,12 @@ public class OverlayRenderer
             if (direction)
             {
                 fi.dy.masa.malilib.render.RenderUtils.renderBlockTargetingOverlay(
-                        entity, pos, trace.getDirection(), trace.getLocation(), color, posMatrix);
+                        entity, pos, trace.getDirection(), trace.getLocation(), color);
             }
             else
             {
                 fi.dy.masa.malilib.render.RenderUtils.renderBlockTargetingOverlaySimple(
-                        entity, pos, trace.getDirection(), color, posMatrix);
+                        entity, pos, trace.getDirection(), color);
             }
         }
 

--- a/src/main/java/fi/dy/masa/litematica/render/RenderUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/render/RenderUtils.java
@@ -6,9 +6,9 @@ import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.block.model.BakedQuad;
-import net.minecraft.client.renderer.block.model.BlockModelPart;
-import net.minecraft.client.renderer.block.model.BlockStateModel;
+import net.minecraft.client.resources.model.geometry.BakedQuad;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Vec3i;
@@ -56,15 +56,15 @@ public class RenderUtils
     /**
      * Assumes a BufferBuilder in the GL_LINES mode has been initialized
      */
-    public static void drawDebugBlockModelOutlinesBatched(List<BlockModelPart> modelParts, BlockState state, BlockPos pos, Color4f color, double expand, float lineWidth, BufferBuilder buffer)
+    public static void drawDebugBlockModelOutlinesBatched(List<BlockStateModelPart> modelParts, BlockState state, BlockPos pos, Color4f color, double expand, float lineWidth, BufferBuilder buffer)
     {
-        for (final BlockModelPart part : modelParts)
+        for (final BlockStateModelPart part : modelParts)
         {
             drawDebugBlockModelOutlinesBatched(part, state, pos, color, expand, lineWidth, buffer);
         }
     }
 
-    public static void drawDebugBlockModelOutlinesBatched(BlockModelPart modelPart, BlockState state, BlockPos pos, Color4f color, double expand, float lineWidth, BufferBuilder buffer)
+    public static void drawDebugBlockModelOutlinesBatched(BlockStateModelPart modelPart, BlockState state, BlockPos pos, Color4f color, double expand, float lineWidth, BufferBuilder buffer)
     {
         for (final Direction side : fi.dy.masa.malilib.util.position.PositionUtils.ALL_DIRECTIONS)
         {
@@ -74,7 +74,7 @@ public class RenderUtils
         renderDebugModelQuadOutlines(modelPart, state, pos, null, color, expand, lineWidth, buffer);
     }
 
-    public static void renderDebugModelQuadOutlines(BlockModelPart modelPart, BlockState state, BlockPos pos, Direction side, Color4f color, double expand, float lineWidth, BufferBuilder buffer)
+    public static void renderDebugModelQuadOutlines(BlockStateModelPart modelPart, BlockState state, BlockPos pos, Direction side, Color4f color, double expand, float lineWidth, BufferBuilder buffer)
     {
         try
         {
@@ -131,17 +131,17 @@ public class RenderUtils
         buffer.addVertex(fx[0], fy[0], fz[0]).setColor(color.r, color.g, color.b, color.a).setLineWidth(lineWidth);
     }
 
-    public static void drawBlockModelOutlinesBatched(List<BlockModelPart> modelParts, BlockState state, BlockPos pos,
+    public static void drawBlockModelOutlinesBatched(List<BlockStateModelPart> modelParts, BlockState state, BlockPos pos,
                                                      Color4f color, double expand, float lineWidth,
                                                      BufferBuilder buffer, PoseStack matrices)
     {
-        for (final BlockModelPart part : modelParts)
+        for (final BlockStateModelPart part : modelParts)
         {
             drawBlockModelOutlinesBatched(part, state, pos, color, expand, lineWidth, buffer, matrices);
         }
     }
 
-    public static void drawBlockModelOutlinesBatched(BlockModelPart modelPart, BlockState state, BlockPos pos,
+    public static void drawBlockModelOutlinesBatched(BlockStateModelPart modelPart, BlockState state, BlockPos pos,
                                                      Color4f color, double expand, float lineWidth,
                                                      BufferBuilder buffer, PoseStack matrices)
     {
@@ -153,7 +153,7 @@ public class RenderUtils
         renderModelQuadOutlines(modelPart, state, pos, null, color, expand, lineWidth, buffer, matrices);
     }
 
-    public static void renderModelQuadOutlines(BlockModelPart modelPart, BlockState state,
+    public static void renderModelQuadOutlines(BlockStateModelPart modelPart, BlockState state,
                                                BlockPos pos, Direction side,
                                                Color4f color, double expand, float lineWidth,
                                                BufferBuilder buffer,
@@ -219,20 +219,22 @@ public class RenderUtils
 
     public static boolean stateModelHasQuads(BlockState state)
     {
-        return modelHasQuads(Objects.requireNonNull(Minecraft.getInstance().getBlockRenderer().getBlockModel(state)));
+        return modelHasQuads(Objects.requireNonNull(Minecraft.getInstance().getModelManager().getBlockStateModelSet().get(state)));
     }
 
     public static boolean modelHasQuads(@Nonnull BlockStateModel model)
     {
-        return hasQuads(model.collectParts(RAND));
+        List<BlockStateModelPart> parts = new java.util.ArrayList<>();
+        model.collectParts(RAND, parts);
+        return hasQuads(parts);
     }
 
-    public static boolean hasQuads(List<BlockModelPart> modelParts)
+    public static boolean hasQuads(List<BlockStateModelPart> modelParts)
     {
         if (modelParts.isEmpty()) return false;
         int totalSize = 0;
 
-        for (BlockModelPart part : modelParts)
+        for (BlockStateModelPart part : modelParts)
         {
             for (Direction face : fi.dy.masa.malilib.util.position.PositionUtils.ALL_DIRECTIONS)
             {
@@ -245,20 +247,20 @@ public class RenderUtils
         return totalSize > 0;
     }
 
-    public static void drawBlockModelQuadOverlayBatched(List<BlockModelPart> modelParts,
+    public static void drawBlockModelQuadOverlayBatched(List<BlockStateModelPart> modelParts,
                                                         BlockState state, BlockPos pos,
                                                         Color4f color, double expand,
                                                         BufferBuilder buffer)
     {
 //        System.out.printf("drawBlockModelQuadOverlayBatched - pos [%s], parts [%d], state [%s]\n", pos.toShortString(), modelParts.size(), state.toString());
 
-        for (final BlockModelPart part : modelParts)
+        for (final BlockStateModelPart part : modelParts)
         {
             drawBlockModelQuadOverlayBatched(part, state, pos, color, expand, buffer);
         }
     }
 
-    public static void drawBlockModelQuadOverlayBatched(BlockModelPart modelPart,
+    public static void drawBlockModelQuadOverlayBatched(BlockStateModelPart modelPart,
                                                         BlockState state, BlockPos pos,
                                                         Color4f color, double expand,
                                                         BufferBuilder buffer)
@@ -271,7 +273,7 @@ public class RenderUtils
         drawBlockModelQuadOverlayBatched(modelPart, state, pos, null, color, expand, buffer);
     }
 
-    public static void drawBlockModelQuadOverlayBatched(BlockModelPart modelPart,
+    public static void drawBlockModelQuadOverlayBatched(BlockStateModelPart modelPart,
                                                         BlockState state, BlockPos pos,
                                                         Direction side,
                                                         Color4f color, double expand,

--- a/src/main/java/fi/dy/masa/litematica/render/infohud/IInfoHudRenderer.java
+++ b/src/main/java/fi/dy/masa/litematica/render/infohud/IInfoHudRenderer.java
@@ -1,7 +1,7 @@
 package fi.dy.masa.litematica.render.infohud;
 
 import java.util.List;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import fi.dy.masa.malilib.config.HudAlignment;
 
 public interface IInfoHudRenderer
@@ -42,7 +42,7 @@ public interface IInfoHudRenderer
      * @param alignment the screen position to render at
      * @return the required y height used up for the rendered content
      */
-    default int render(GuiGraphics drawContext, int xOffset, int yOffset, HudAlignment alignment)
+    default int render(GuiGraphicsExtractor drawContext, int xOffset, int yOffset, HudAlignment alignment)
     {
         return 0;
     }

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/BlockModelRendererSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/BlockModelRendererSchematic.java
@@ -9,18 +9,21 @@ import net.minecraft.CrashReportCategory;
 import net.minecraft.ReportedException;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.color.block.BlockColors;
-import net.minecraft.client.renderer.ItemBlockRenderTypes;
+import net.minecraft.client.color.block.BlockTintSource;
 import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.util.ARGB;
+import com.mojang.blaze3d.vertex.QuadInstance;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.block.BlockRenderDispatcher;
-import net.minecraft.client.renderer.block.LiquidBlockRenderer;
-import net.minecraft.client.renderer.block.model.BakedQuad;
-import net.minecraft.client.renderer.block.model.BlockModelPart;
-import net.minecraft.client.renderer.block.model.BlockStateModel;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelDispatcher;
+import net.minecraft.client.renderer.block.FluidRenderer;
+import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
+import net.minecraft.client.resources.model.geometry.BakedQuad;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 import net.minecraft.client.resources.model.ModelManager;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.state.BlockState;
@@ -33,7 +36,6 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import fi.dy.masa.litematica.config.Configs;
 import fi.dy.masa.litematica.data.DataManager;
-import fi.dy.masa.litematica.mixin.render.IMixinBlockRenderManager;
 import fi.dy.masa.litematica.render.LitematicaRenderer;
 import fi.dy.masa.litematica.render.schematic.ao.*;
 
@@ -42,14 +44,13 @@ public class BlockModelRendererSchematic
 	public static final ThreadLocal<AOBrightness> BRIGHTNESS_CACHE = ThreadLocal.withInitial(AOBrightness::new);
     private final SingleThreadedRandomSource random;
     private final BlockColors colorMap;
-    private LiquidBlockRenderer liquidRenderer;
     private ModelManager bakedManager;
+    private final QuadInstance quadInstance = new QuadInstance();
 
-    public BlockModelRendererSchematic(BlockColors blockColorsIn, BlockRenderDispatcher manager)
+    public BlockModelRendererSchematic(BlockColors blockColorsIn)
     {
 		this.random = new SingleThreadedRandomSource(42L);
         this.colorMap = blockColorsIn;
-        this.reload(manager);
     }
 
 	public static void enableCache()
@@ -68,9 +69,9 @@ public class BlockModelRendererSchematic
 		}
 	}
 
-	public void reload(BlockRenderDispatcher manager)
+	public void reload(BlockStateModelDispatcher manager)
 	{
-		this.liquidRenderer = ((IMixinBlockRenderManager) manager).litematica_getFluidRenderer();
+        // no-op in 26.1.x — FluidRenderer is created on-demand from ModelManager
 	}
 
     public void setBakedManager(ModelManager manager)
@@ -88,14 +89,14 @@ public class BlockModelRendererSchematic
 		this.random.setSeed(seed);
 	}
 
-    public boolean renderModel(BlockAndTintGetter worldIn, List<BlockModelPart> modelParts,
+    public boolean renderModel(BlockAndTintGetter worldIn, List<BlockStateModelPart> modelParts,
                                BlockState stateIn, BlockPos posIn,
                                PoseStack matrices, VertexConsumer vertexConsumer,
                                boolean cull, int overlay)
     {
 		if (!modelParts.isEmpty())
 		{
-			boolean ao = Minecraft.useAmbientOcclusion() &&
+			boolean ao = Minecraft.getInstance().options.ambientOcclusion().get() &&
 					stateIn.getLightEmission() == 0 && modelParts.getFirst().useAmbientOcclusion();
 
 			Vec3 offset = stateIn.getOffset(posIn);
@@ -128,7 +129,7 @@ public class BlockModelRendererSchematic
 	    return false;
     }
 
-    public boolean renderModelFlat(BlockAndTintGetter worldIn, List<BlockModelPart> modelParts,
+    public boolean renderModelFlat(BlockAndTintGetter worldIn, List<BlockStateModelPart> modelParts,
                                    BlockState stateIn, BlockPos posIn,
                                    PoseStack matrices, VertexConsumer vertexConsumer,
                                    int overlay, boolean cull)
@@ -139,7 +140,7 @@ public class BlockModelRendererSchematic
 	    int i = 0;
 	    int j = 0;
 
-        for (BlockModelPart part : modelParts)
+        for (BlockStateModelPart part : modelParts)
         {
             for (Direction side : PositionUtils.ALL_DIRECTIONS)
             {
@@ -194,7 +195,7 @@ public class BlockModelRendererSchematic
         return renderedSomething;
     }
 
-	public boolean renderModelSmooth(BlockAndTintGetter worldIn, List<BlockModelPart> modelParts, BlockState stateIn, BlockPos posIn,
+	public boolean renderModelSmooth(BlockAndTintGetter worldIn, List<BlockStateModelPart> modelParts, BlockState stateIn, BlockPos posIn,
 	                                 PoseStack matrices, VertexConsumer vertexConsumer,
 	                                 int overlay, boolean cull)
 	{
@@ -204,7 +205,7 @@ public class BlockModelRendererSchematic
 		int i = 0;
 		int j = 0;
 
-		for (BlockModelPart part : modelParts)
+		for (BlockStateModelPart part : modelParts)
 		{
 			for (Direction side : PositionUtils.ALL_DIRECTIONS)
 			{
@@ -279,10 +280,11 @@ public class BlockModelRendererSchematic
                 BlockPos blockPos = lightmap.hasOffset ? lightmap.pos.setWithOffset(pos, bakedQuad.direction()) : pos;
                 light = lightmap.brightnessCache.isEnabled()
                         ? lightmap.brightnessCache.getInt(state, world, pos)
-                        : LevelRenderer.getLightColor(world, blockPos);
+                        : LevelRenderer.getLightCoords(world, blockPos);
             }
 
-            float b = world.getShade(bakedQuad.direction(), bakedQuad.shade());
+            boolean shade = bakedQuad.materialInfo().shade();
+            float b = shade ? world.cardinalLighting().byFace(bakedQuad.direction()) : 1.0F;
 //            float[] bo = new float[]{b, b, b, b};
 //	          int[] lo = new int[]{light, light, light, light};
 
@@ -308,7 +310,7 @@ public class BlockModelRendererSchematic
 		for (BakedQuad bakedQuad : quads)
 		{
 			this.getQuadDimensions(world, state, pos, bakedQuad, ao);
-			ao.apply(world, state, pos, bakedQuad.direction(), bakedQuad.shade());
+			ao.apply(world, state, pos, bakedQuad.direction(), bakedQuad.materialInfo().shade());
 			//System.out.printf("renderQuad(): pos [%s] / state [%s] / quad face [%s]\n", pos.toShortString(), state, bakedQuad.getFace().getName());
 			this.renderQuad(world, state, pos, vertexConsumer, matrices, bakedQuad, ao, overlay);
 		}
@@ -320,13 +322,13 @@ public class BlockModelRendererSchematic
                             AOLightmap lightmap,
                             int overlay)
     {
-		int tint = quad.tintIndex();
+		int tint = quad.materialInfo().tintIndex();
         float r;
         float g;
         float b;
 	    float a;
 
-        if (quad.isTinted())
+        if (quad.materialInfo().isTinted())
         {
             int color;
 
@@ -336,7 +338,8 @@ public class BlockModelRendererSchematic
 			}
 			else
 			{
-				color = this.colorMap.getColor(state, world, pos, tint);
+				BlockTintSource src = this.colorMap.getTintSource(state, tint);
+					color = (src != null) ? src.colorInWorld(state, world, pos) : -1;
 				lightmap.lastTintIndex = tint;
 				lightmap.colorOfLastTintIndex = color;
 			}
@@ -355,7 +358,16 @@ public class BlockModelRendererSchematic
 	    a = 1.0f;
 
         //System.out.printf("quad(): pos [%s] / state [%s] --> SPRITE [%s]\n", pos.toShortString(), state, quad.getSprite().toString());
-        vertexConsumer.putBulkData(matrices.last(), quad, lightmap.fs, r, g, b, a, lightmap.is, overlay);
+        for (int i = 0; i < 4; i++)
+        {
+            this.quadInstance.setColor(i, ARGB.color(Math.clamp((int)(a * 255), 0, 255),
+                                                     Math.clamp((int)(r * lightmap.fs[i] * 255), 0, 255),
+                                                     Math.clamp((int)(g * lightmap.fs[i] * 255), 0, 255),
+                                                     Math.clamp((int)(b * lightmap.fs[i] * 255), 0, 255)));
+            this.quadInstance.setLightCoords(i, lightmap.is[i]);
+        }
+        this.quadInstance.setOverlayCoords(overlay);
+        vertexConsumer.putBakedQuad(matrices.last(), quad, this.quadInstance);
     }
 
     private void getQuadDimensions(BlockAndTintGetter world, BlockState state, BlockPos pos,
@@ -448,7 +460,7 @@ public class BlockModelRendererSchematic
 		}
 
 		this.renderQuadsModel(entry, vertexConsumer,
-		                      this.bakedManager.getBlockModelShaper().getBlockModel(state),
+		                      this.bakedManager.getBlockStateModelSet().get(state),
 		                      rgb, light, overlay, state);
 	}
 
@@ -457,7 +469,8 @@ public class BlockModelRendererSchematic
 	                             float[] rgb, int light, int overlay,
 	                             @Nullable BlockState fallbackState)
 	{
-		List<BlockModelPart> parts = model.collectParts(this.random);
+		List<BlockStateModelPart> parts = new java.util.ArrayList<>();
+		model.collectParts(this.random, parts);
 		if (rgb.length < 3)
 		{
 			rgb = new float[]{1.0f, 1.0f, 1.0f};
@@ -466,8 +479,9 @@ public class BlockModelRendererSchematic
 		if (parts.isEmpty() && fallbackState != null)
 		{
 			BlockState state = LitematicaRenderer.getInstance().getWorldRenderer().getFallbackState(fallbackState);
-			model = this.bakedManager.getBlockModelShaper().getBlockModel(state);
-			parts = model.collectParts(this.random);
+			model = this.bakedManager.getBlockStateModelSet().get(state);
+			parts = new java.util.ArrayList<>();
+			model.collectParts(this.random, parts);
 		}
 
 		// Because of other mods.
@@ -476,14 +490,14 @@ public class BlockModelRendererSchematic
 			return;
 		}
 
-		for (BlockModelPart part : parts)
+		for (BlockStateModelPart part : parts)
 		{
 			this.renderQuadsPart(entry, vertexConsumer, part, rgb, light, overlay);
 		}
 	}
 
 	public void renderQuadsPart(PoseStack.Pose entry, VertexConsumer vertexConsumer,
-	                            BlockModelPart part,
+	                            BlockStateModelPart part,
 	                            float[] rgb, int light, int overlay)
 	{
 		if (rgb.length < 3)
@@ -515,14 +529,18 @@ public class BlockModelRendererSchematic
 			float blue = 1.0f;
 			float alpha = 1.0f;
 
-			if (quad.isTinted())
+			if (quad.materialInfo().isTinted())
 			{
 				red = MathUtils.clamp(rgb[0], 0.0f, 1.0f);
 				green = MathUtils.clamp(rgb[1], 0.0f, 1.0f);
 				blue = MathUtils.clamp(rgb[2], 0.0f, 1.0f);
 			}
 
-			vertexConsumer.putBulkData(entry, quad, red, green, blue, alpha, light, overlay);
+			int color = ARGB.color((int)(alpha * 255), (int)(red * 255), (int)(green * 255), (int)(blue * 255));
+			this.quadInstance.setColor(color);
+			this.quadInstance.setLightCoords(light);
+			this.quadInstance.setOverlayCoords(overlay);
+			vertexConsumer.putBakedQuad(entry, quad, this.quadInstance);
 		}
 	}
 
@@ -531,7 +549,8 @@ public class BlockModelRendererSchematic
     {
         try
         {
-            this.liquidRenderer.tesselate(world, pos, consumer, stateIn, fluid);
+            new FluidRenderer(Minecraft.getInstance().getModelManager().getFluidStateModelSet())
+                .tesselate(world, pos, (ChunkSectionLayer layer) -> consumer, stateIn, fluid);
         }
         catch (Throwable var9)
         {
@@ -551,14 +570,19 @@ public class BlockModelRendererSchematic
             return false;
         }
 
-        BlockStateModel model = this.bakedManager.getBlockModelShaper().getBlockModel(stateIn);
-        int i = this.colorMap.getColor(stateIn, null, null, 0);
+        BlockStateModel model = this.bakedManager.getBlockStateModelSet().get(stateIn);
+        BlockTintSource tintSrc = this.colorMap.getTintSource(stateIn, 0);
+        int i = (tintSrc != null) ? tintSrc.color(stateIn) : -1;
         float red = (float) (i >> 16 & 0xFF) / 255.0f;
         float green = (float) (i >> 8 & 0xFF) / 255.0f;
         float blue = (float) (i & 0xFF) / 255.0f;
+        List<BlockStateModelPart> parts = new java.util.ArrayList<>();
+        model.collectParts(this.random, parts);
+        var renderType = parts.isEmpty() ? null : parts.getFirst().getQuads(null).isEmpty() ? null : parts.getFirst().getQuads(null).getFirst().materialInfo().itemRenderType();
+        if (renderType == null) return false;
 
         this.renderQuadsModel(matrices.last(),
-                              consumer.getBuffer(ItemBlockRenderTypes.getRenderType(stateIn)),
+                              consumer.getBuffer(renderType),
                               model,
                               new float[]{red, green, blue},
                               light, overlay,

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkCacheSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkCacheSchematic.java
@@ -7,6 +7,8 @@ import org.jspecify.annotations.NonNull;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
+import net.minecraft.world.level.CardinalLighting;
 import net.minecraft.world.level.*;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -135,9 +137,9 @@ public class ChunkCacheSchematic implements BlockAndTintGetter, LightChunkGetter
     }
 
     @Override
-    public float getShade(@Nonnull Direction direction, boolean bl)
+    public CardinalLighting cardinalLighting()
     {
-        return this.worldClient.getShade(direction, bl); // AO brightness on face
+        return this.worldClient.cardinalLighting();
     }
 
     @Override

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRenderBatchDraw.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRenderBatchDraw.java
@@ -57,7 +57,7 @@ public record ChunkRenderBatchDraw(
 
 			pass.setUniform("ChunkFix", this.chunkFixUBO);
 			pass.bindTexture("Sampler2",
-			                 mc.gameRenderer.lightTexture().getTextureView(),
+			                 mc.gameRenderer.lightmap(),
 			                 RenderSystem.getSamplerCache().getClampToEdge(FilterMode.LINEAR)
 			);
 

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRenderDispatcherSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRenderDispatcherSchematic.java
@@ -169,7 +169,7 @@ public class ChunkRenderDispatcherSchematic
 
     protected Optional<ChunkRendererSchematicVbo> getOrCreateChunkRenderer(int chunkX, int chunkZ)
     {
-        long index = ChunkPos.asLong(chunkX, chunkZ);
+        long index = ChunkPos.pack(chunkX, chunkZ);
 
         try
         {

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRenderLayers.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRenderLayers.java
@@ -28,7 +28,6 @@ public record ChunkRenderLayers()
         list.add(ChunkSectionLayer.SOLID);
         list.add(ChunkSectionLayer.CUTOUT);
         list.add(ChunkSectionLayer.TRANSLUCENT);
-        list.add(ChunkSectionLayer.TRIPWIRE);
 
         return list;
     }
@@ -37,10 +36,9 @@ public record ChunkRenderLayers()
     {
         HashMap<ChunkSectionLayer, Pair<RenderPipeline, RenderPipeline>> map = new HashMap<>();
 
-        map.put(ChunkSectionLayer.SOLID,         Pair.of(MaLiLibPipelines.LEGACY_SOLID_TERRAIN_MASA,       MaLiLibPipelines.LEGACY_SOLID_TERRAIN_MASA_OFFSET));
-        map.put(ChunkSectionLayer.CUTOUT,        Pair.of(MaLiLibPipelines.LEGACY_CUTOUT_TERRAIN_MASA,      MaLiLibPipelines.LEGACY_CUTOUT_TERRAIN_MASA_OFFSET));
-        map.put(ChunkSectionLayer.TRANSLUCENT,   Pair.of(MaLiLibPipelines.LEGACY_TRANSLUCENT_MASA,         MaLiLibPipelines.LEGACY_TRANSLUCENT_MASA_OFFSET));
-        map.put(ChunkSectionLayer.TRIPWIRE,      Pair.of(MaLiLibPipelines.LEGACY_TRIPWIRE_TERRAIN_MASA,    MaLiLibPipelines.LEGACY_TRIPWIRE_TERRAIN_MASA_OFFSET));
+        map.put(ChunkSectionLayer.SOLID,       Pair.of(MaLiLibPipelines.LEGACY_SOLID_TERRAIN,   MaLiLibPipelines.LEGACY_SOLID_TERRAIN_OFFSET));
+        map.put(ChunkSectionLayer.CUTOUT,      Pair.of(MaLiLibPipelines.LEGACY_CUTOUT_TERRAIN,  MaLiLibPipelines.LEGACY_CUTOUT_TERRAIN_OFFSET));
+        map.put(ChunkSectionLayer.TRANSLUCENT, Pair.of(MaLiLibPipelines.LEGACY_TRANSLUCENT,     MaLiLibPipelines.LEGACY_TRANSLUCENT_OFFSET));
 
         return map;
     }
@@ -53,7 +51,7 @@ public record ChunkRenderLayers()
 	    list.add(RenderTypes.solidMovingBlock());
 	    list.add(RenderTypes.cutoutMovingBlock());
 	    list.add(RenderTypes.translucentMovingBlock());
-	    list.add(RenderTypes.tripwireMovingBlock());
+	    // RenderTypes.tripwireMovingBlock() removed in 26.1.x
 	    list.add(RenderTypes.endPortal());
 	    list.add(RenderTypes.endGateway());
 

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRenderWorkerLitematica.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRenderWorkerLitematica.java
@@ -67,7 +67,7 @@ public class ChunkRenderWorkerLitematica implements Runnable
             catch (Throwable throwable)
             {
                 CrashReport crashreport = CrashReport.forThrowable(throwable, "Batching chunks");
-                Minecraft.getInstance().delayCrashRaw(Minecraft.getInstance().fillReport(crashreport));
+                Minecraft.getInstance().delayCrash(Minecraft.getInstance().fillReport(crashreport));
                 return;
             }
         }
@@ -261,7 +261,7 @@ public class ChunkRenderWorkerLitematica implements Runnable
 
                     if ((throwable instanceof CancellationException) == false && (throwable instanceof InterruptedException) == false)
                     {
-                        Minecraft.getInstance().delayCrashRaw(CrashReport.forThrowable(throwable, "Rendering Litematica chunk"));
+                        Minecraft.getInstance().delayCrash(Minecraft.getInstance().fillReport(CrashReport.forThrowable(throwable, "Rendering Litematica chunk")));
                     }
                 }
             }, MoreExecutors.directExecutor());

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRendererSchematicVbo.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRendererSchematicVbo.java
@@ -16,8 +16,7 @@ import com.mojang.blaze3d.vertex.*;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
-import net.minecraft.client.renderer.ItemBlockRenderTypes;
-import net.minecraft.client.renderer.block.model.BlockModelPart;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
@@ -555,9 +554,9 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
         this.getProfiler().pop();
         this.profiler = null;
 
-        if (this.worldRenderer.getChunkSchematicState(this.chunkPosition.x, this.chunkPosition.z).atLeast(ChunkSchematicState.RENDERED))
+        if (this.worldRenderer.getChunkSchematicState(this.chunkPosition.x(), this.chunkPosition.z()).atLeast(ChunkSchematicState.RENDERED))
         {
-            this.worldRenderer.setChunkSchematicState(this.chunkPosition.x, this.chunkPosition.z, ChunkSchematicState.RENDERED);
+            this.worldRenderer.setChunkSchematicState(this.chunkPosition.x(), this.chunkPosition.z(), ChunkSchematicState.RENDERED);
         }
 
         data.setTimeBuilt(this.world.getGameTime());
@@ -683,7 +682,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
                 Configs.Visuals.ENABLE_SCHEMATIC_FLUIDS.getBooleanValue())
             {
                 this.getProfiler().popPush("render_build_fluids");
-                ChunkSectionLayer layer = ItemBlockRenderTypes.getRenderLayer(fluidState);
+                ChunkSectionLayer layer = Minecraft.getInstance().getModelManager().getFluidStateModelSet().get(fluidState).layer();
                 int offsetY = ((pos.getY() >> 4) << 4) - this.position.getY();
                 BufferBuilder bufferSchematic = this.builderCache.getBufferByBlockLayer(layer, allocators);
 
@@ -703,7 +702,22 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
             if (stateSchematic.getRenderShape() != RenderShape.INVISIBLE)
             {
                 this.getProfiler().popPush("render_build_blocks");
-                ChunkSectionLayer layer = translucent ? ChunkSectionLayer.TRANSLUCENT : ItemBlockRenderTypes.getChunkRenderType(stateSchematic);
+                ChunkSectionLayer layer;
+                if (translucent)
+                {
+                    layer = ChunkSectionLayer.TRANSLUCENT;
+                }
+                else
+                {
+                    List<BlockStateModelPart> parts = this.worldRenderer.getModelParts(pos, stateSchematic, this.rand);
+                    layer = ChunkSectionLayer.SOLID;
+                    if (!parts.isEmpty())
+                    {
+                        var quads = parts.getFirst().getQuads(null);
+                        if (quads.isEmpty()) quads = parts.getFirst().getQuads(Direction.UP);
+                        if (!quads.isEmpty()) layer = quads.getFirst().materialInfo().layer();
+                    }
+                }
                 BufferBuilder bufferSchematic = this.builderCache.getBufferByBlockLayer(layer, allocators);
 
                 if (!data.isBlockLayerStarted(layer) || bufferSchematic == null)
@@ -810,7 +824,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
             {
                 this.getProfiler().popPush("cull_inner_sides");
                 BlockPos.MutableBlockPos posMutable = new BlockPos.MutableBlockPos();
-                List<BlockModelPart> modelParts = this.worldRenderer.getModelParts(relPos, stateSchematic, this.rand);
+                List<BlockStateModelPart> modelParts = this.worldRenderer.getModelParts(relPos, stateSchematic, this.rand);
 
                 if (RenderUtils.hasQuads(modelParts))
                 {
@@ -837,7 +851,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
                             {
                                 this.getProfiler().popPush("cull_render_model");
 
-                                for (BlockModelPart part : modelParts)
+                                for (BlockStateModelPart part : modelParts)
                                 {
 //                                final int light = WorldRenderer.getLightmapCoordinates(this.schematicWorldView, relPos);
 //                                    LOGGER.warn("renderOverlay: Batched Block Model Side Quads [{}] -->", side.asString());
@@ -863,7 +877,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
                 if (missing && Configs.Visuals.SCHEMATIC_OVERLAY_MODEL_SIDES.getBooleanValue())
                 {
                     this.getProfiler().popPush("render_model_sides");
-                    List<BlockModelPart> modelParts = this.worldRenderer.getModelParts(relPos, stateSchematic, this.rand);
+                    List<BlockStateModelPart> modelParts = this.worldRenderer.getModelParts(relPos, stateSchematic, this.rand);
 
                     if (RenderUtils.hasQuads(modelParts))
                     {
@@ -968,7 +982,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
                          */
 
                         this.getProfiler().popPush("render_model_batched");
-                        List<BlockModelPart> modelParts = this.worldRenderer.getModelParts(relPos, stateSchematic, this.rand);
+                        List<BlockStateModelPart> modelParts = this.worldRenderer.getModelParts(relPos, stateSchematic, this.rand);
 
                         if (RenderUtils.hasQuads(modelParts))
                         {
@@ -992,7 +1006,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
                 if (missing && Configs.Visuals.SCHEMATIC_OVERLAY_MODEL_OUTLINE.getBooleanValue())
                 {
                     this.getProfiler().popPush("render_model_batched");
-                    List<BlockModelPart> modelParts = this.worldRenderer.getModelParts(relPos, stateSchematic, this.rand);
+                    List<BlockStateModelPart> modelParts = this.worldRenderer.getModelParts(relPos, stateSchematic, this.rand);
 
                     if (RenderUtils.hasQuads(modelParts))
                     {

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/SchematicRenderState.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/SchematicRenderState.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;
-import net.minecraft.client.renderer.state.CameraRenderState;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
 
 public class SchematicRenderState
 {

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/WorldRendererSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/WorldRendererSchematic.java
@@ -27,10 +27,11 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.ClientMannequin;
 import net.minecraft.client.renderer.DynamicUniforms;
 import net.minecraft.client.renderer.SubmitNodeCollector;
-import net.minecraft.client.renderer.block.BlockRenderDispatcher;
-import net.minecraft.client.renderer.block.model.BakedQuad;
-import net.minecraft.client.renderer.block.model.BlockModelPart;
-import net.minecraft.client.renderer.block.model.BlockStateModel;
+import net.minecraft.client.renderer.block.FluidRenderer;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelDispatcher;
+import net.minecraft.client.resources.model.geometry.BakedQuad;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
 import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
@@ -39,7 +40,7 @@ import net.minecraft.client.renderer.culling.Frustum;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.client.renderer.fog.FogRenderer;
-import net.minecraft.client.renderer.state.LevelRenderState;
+import net.minecraft.client.renderer.state.level.LevelRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.core.BlockPos;
@@ -57,7 +58,7 @@ import net.minecraft.world.entity.animal.fish.Cod;
 import net.minecraft.world.entity.animal.fish.Salmon;
 import net.minecraft.world.entity.animal.fish.TropicalFish;
 import net.minecraft.world.entity.animal.frog.Tadpole;
-import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.RenderShape;
@@ -96,7 +97,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     private final Minecraft mc;
     private final EntityRenderDispatcher entityRenderManager;
     private final BlockEntityRenderDispatcher blockEntityRenderManager;
-    private BlockRenderDispatcher blockRenderManager;
+    // blockRenderManager removed in 26.1.x — use mc.getModelManager() directly
     private final BlockModelRendererSchematic blockModelRenderer;
     private final Set<BlockEntity> blockEntities;
     private final List<ChunkRendererSchematicVbo> renderInfos;
@@ -139,13 +140,12 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     {
         this.mc = mc;
         this.renderChunkFactory = ChunkRendererSchematicVbo::new;
-        this.blockRenderManager = Minecraft.getInstance().getBlockRenderer();
 	    this.blockEntities = new HashSet<>();
 	    this.renderInfos = new ArrayList<>(1024);
         this.renderedEntities = new HashMap<>();
         this.entityRenderManager = mc.getEntityRenderDispatcher();
         this.blockEntityRenderManager = mc.getBlockEntityRenderDispatcher();
-        this.blockModelRenderer = new BlockModelRendererSchematic(mc.getBlockColors(), this.blockRenderManager);
+        this.blockModelRenderer = new BlockModelRendererSchematic(mc.getBlockColors());
         this.blockModelRenderer.setBakedManager(mc.getModelManager());
         this.fogRenderer = ((IMixinGameRenderer) mc.gameRenderer).litematica_getFogRenderer();
 		this.schematicRenderState = new SchematicRenderState();
@@ -459,7 +459,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
         final int centerChunkX = (viewPos.getX() >> 4);
         final int centerChunkZ = (viewPos.getZ() >> 4);
         final int renderDistance = this.mc.options.renderDistance().get() + 2;
-        ChunkPos viewChunk = new ChunkPos(viewPos);
+        ChunkPos viewChunk = ChunkPos.containing(viewPos);
 
         this.displayListEntitiesDirty = this.displayListEntitiesDirty || !this.chunksToUpdate.isEmpty() ||
                 entityX != this.lastCameraX ||
@@ -500,8 +500,8 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
             for (ChunkPos chunkPos : positions)
             {
                 //SubChunkPos subChunk = queuePositions.poll();
-                int cx = chunkPos.x;
-                int cz = chunkPos.z;
+                int cx = chunkPos.x();
+                int cz = chunkPos.z();
                 //LOGGER.warn("[WorldRenderer] setupTerrain() position[{}], chunkPos: {} // isLoaded: [{}]", count, chunkPos.toString(), this.world.getChunkProvider().hasChunk(chunkPos.x, chunkPos.z));
                 // Only render sub-chunks that are within the client's render distance, and that
                 // have been already properly loaded on the client
@@ -747,12 +747,13 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
                     ));
 
                     renderMap.get(layer)
-                             .add(new RenderPass.Draw<>(
+                             .add(new RenderPass.Draw<GpuBufferSlice[]>(
                                      0, buffers.getVertexBuffer(),
                                      vertexBuffer, indexType,
                                      0, buffers.getIndexCount(),
+                                     0,
                                      (slices, uploader) ->
-                                             uploader.upload("DynamicTransforms", ((GpuBufferSlice[]) slices)[pos])
+                                             uploader.upload("DynamicTransforms", slices[pos])
                              ));
 
 //                    int pos = chunkValues.size();
@@ -873,7 +874,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
 		this.schematicRenderState.cameraState.initialized = camera.isInitialized();
 		this.schematicRenderState.cameraState.pos = camera.position();
 		this.schematicRenderState.cameraState.blockPos = camera.blockPosition();
-		this.schematicRenderState.cameraState.entityPos = camera.entity().getRopeHoldPosition(tickProgress);
+		// entityPos removed from CameraRenderState in 26.1.x
 		this.schematicRenderState.cameraState.orientation = new Quaternionf(camera.rotation());
 	}
 
@@ -1005,7 +1006,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
                 boolean result;
 
                 this.blockModelRenderer.setSeed(state.getSeed(pos));
-                List<BlockModelPart> parts = this.getModelParts(pos, state, this.blockModelRenderer.getRandom());
+                List<BlockStateModelPart> parts = this.getModelParts(pos, state, this.blockModelRenderer.getRandom());
 
                 result = renderType == RenderShape.MODEL &&
                         this.blockModelRenderer.renderModel(world, parts, state, pos, matrixStack, bufferBuilderIn, false, OverlayTexture.NO_OVERLAY);
@@ -1038,10 +1039,10 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     public void renderFluid(BlockAndTintGetter world, BlockState blockState, FluidState fluidState, BlockPos pos, BufferBuilder bufferBuilderIn)
     {
         this.getProfiler().push("render_fluid");
-        // Sometimes this collides with FAPI
         try
         {
-            this.blockRenderManager.renderLiquid(pos, world, bufferBuilderIn, blockState, fluidState);
+            new FluidRenderer(this.mc.getModelManager().getFluidStateModelSet())
+                .tesselate(world, pos, layer -> bufferBuilderIn, blockState, fluidState);
         }
         catch (Exception ignored) { }
         this.getProfiler().pop();
@@ -1121,9 +1122,9 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     }
 
     @Override
-    public boolean hasQuadsForModel(List<BlockModelPart> modelParts, BlockState state, @Nullable Direction side)
+    public boolean hasQuadsForModel(List<BlockStateModelPart> modelParts, BlockState state, @Nullable Direction side)
     {
-        BlockModelPart part = modelParts.getFirst();
+        BlockStateModelPart part = modelParts.getFirst();
 
         if (side != null)
         {
@@ -1146,7 +1147,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     }
 
     @Override
-    public boolean hasQuadsForModelPart(BlockModelPart modelPart, BlockState state, @Nullable Direction side)
+    public boolean hasQuadsForModelPart(BlockStateModelPart modelPart, BlockState state, @Nullable Direction side)
     {
         if (side != null)
         {
@@ -1171,23 +1172,24 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     @Override
     public BlockStateModel getModelForState(BlockState state)
     {
-        return this.blockRenderManager.getBlockModelShaper().getBlockModel(state);
+        return this.mc.getModelManager().getBlockStateModelSet().get(state);
     }
 
     @Override
-    public List<BlockModelPart> getModelParts(BlockPos pos, BlockState state, RandomSource rand)
+    public List<BlockStateModelPart> getModelParts(BlockPos pos, BlockState state, RandomSource rand)
     {
-        List<BlockModelPart> parts = this.getModelForState(state).collectParts(rand);
+        List<BlockStateModelPart> parts = new java.util.ArrayList<>();
+        this.getModelForState(state).collectParts(rand, parts);
 
         if (parts.isEmpty())
         {
 			// Try Fallback Blocks first.
-	        parts = this.getModelForState(this.getFallbackState(state)).collectParts(rand);
+	        this.getModelForState(this.getFallbackState(state)).collectParts(rand, parts);
         }
 
 		if (parts.isEmpty())
 		{
-			parts = this.getModelForState(state.getBlock().defaultBlockState()).collectParts(rand);
+			this.getModelForState(state.getBlock().defaultBlockState()).collectParts(rand, parts);
 			LOGGER.warn("getModelParts: Invalid Block Model for block at [{}] with state [{}]; Attempting to reset to default.", pos.toShortString(), state.toString());
 		}
 
@@ -1229,10 +1231,10 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
                 BlockPos pos = chunkRenderer.getOrigin();
                 ChunkPos chunkPos = chunkRenderer.getChunkPos();
 //                ChunkPos chunkPos = new ChunkPos(pos.getX() >> 4, pos.getZ() >> 4);
-                ChunkSchematic chunk = this.world.getChunkSource().getChunkIfExists(chunkPos.x, chunkPos.z);
+                ChunkSchematic chunk = this.world.getChunkSource().getChunkIfExists(chunkPos.x(), chunkPos.z());
 
                 if (chunk == null || chunk.isEmpty() ||
-                    !DataManager.getSchematicPlacementManager().checkIfChunkShouldRender(chunkPos.x, chunkPos.z))
+                    !DataManager.getSchematicPlacementManager().checkIfChunkShouldRender(chunkPos.x(), chunkPos.z()))
                 {
                     continue;
                 }
@@ -1240,7 +1242,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
 //                List<Entity> list = chunk.getEntityList();
 //                AABB bb = chunkRenderer.getBoundingBox();
 //                List<Entity> list = this.world.getEntities((Entity) null, bb, fi.dy.masa.litematica.util.EntityUtils.NOT_PLAYER);
-                ImmutableList<Entity> list = this.world.getEntitiesByChunk(chunkPos.x, chunkPos.z, fi.dy.masa.litematica.util.EntityUtils.NOT_PLAYER);
+                ImmutableList<Entity> list = this.world.getEntitiesByChunk(chunkPos.x(), chunkPos.z(), fi.dy.masa.litematica.util.EntityUtils.NOT_PLAYER);
 
 //                LOGGER.error("[WorldRenderer] prepareEntities: Chunk: {}, EntityList [{}] // BB: [{}]", chunkPos.toString(), list.size(), bb.toString());
 //                LOGGER.warn("[WorldRenderer] prepareEntities: Chunk: [{}], TestList: [{}]", pos.toShortString(), list.size());
@@ -1363,7 +1365,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
         double cameraY = camera.position().y;
         double cameraZ = camera.position().z;
 
-        this.blockEntityRenderManager.prepare(camera);
+        this.blockEntityRenderManager.prepare(camera.position());
         LayerRange layerRange = DataManager.getRenderLayerRange();
 
 		profiler.popPush("block_entities");
@@ -1380,10 +1382,10 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
             {
                 BlockPos chunkOrigin = chunkRenderer.getOrigin();
                 ChunkPos chunkPos = chunkRenderer.getChunkPos();
-                ChunkSchematic chunk = this.world.getChunkSource().getChunkForLighting(chunkPos.x, chunkPos.z);
+                ChunkSchematic chunk = this.world.getChunkSource().getChunkForLighting(chunkPos.x(), chunkPos.z());
 
                 if (chunk == null || chunk.isEmpty() ||
-                    !DataManager.getSchematicPlacementManager().checkIfChunkShouldRender(chunkPos.x, chunkPos.z))
+                    !DataManager.getSchematicPlacementManager().checkIfChunkShouldRender(chunkPos.x(), chunkPos.z()))
                 {
                     continue;
                 }
@@ -1527,9 +1529,8 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     }
 
     @Override
-    public void reloadBlockRenderManager(BlockRenderDispatcher manager)
+    public void reloadBlockRenderManager(BlockStateModelDispatcher manager)
 	{
-		this.blockRenderManager = manager;
-		this.blockModelRenderer.reload(manager);
+        this.blockModelRenderer.reload(manager);
 	}
 }

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ao/AOBrightness.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ao/AOBrightness.java
@@ -5,7 +5,7 @@ import it.unimi.dsi.fastutil.longs.Long2IntLinkedOpenHashMap;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Util;
-import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 
 import fi.dy.masa.litematica.render.IWorldSchematicRenderer;

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ao/AOProcessor.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ao/AOProcessor.java
@@ -3,7 +3,7 @@ package fi.dy.masa.litematica.render.schematic.ao;
 import fi.dy.masa.litematica.config.Configs;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 
 public abstract class AOProcessor extends AOLightmap

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ao/AOProcessorLegacy.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ao/AOProcessorLegacy.java
@@ -2,7 +2,7 @@ package fi.dy.masa.litematica.render.schematic.ao;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 
 /**
@@ -68,7 +68,7 @@ public class AOProcessorLegacy extends AOProcessor
 			this.fs[vertexTranslations.vert3] = b4;
 		}
 
-		float b = world.getShade(face, hasShade);
+		float b = hasShade ? world.cardinalLighting().byFace(face) : 1.0F;
 
 		for (int index = 0; index < this.fs.length; ++index)
 		{

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ao/AOProcessorModern.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ao/AOProcessorModern.java
@@ -2,7 +2,7 @@ package fi.dy.masa.litematica.render.schematic.ao;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 
 /**
@@ -37,13 +37,13 @@ public class AOProcessorModern extends AOProcessor
         int l = this.brightnessCache.getInt(bs4, world, mutable);
         float m = this.brightnessCache.getFloat(bs4, world, mutable);
         BlockState bs5 = world.getBlockState(mutable.setWithOffset(blockPos, nd.corners[0]).move(face));
-        boolean bl2 = !bs5.isViewBlocking(world, mutable) || bs5.getLightBlock() == 0;
+        boolean bl2 = !bs5.isViewBlocking(world, mutable) || bs5.getLightDampening() == 0;
         BlockState bs6 = world.getBlockState(mutable.setWithOffset(blockPos, nd.corners[1]).move(face));
-        boolean bl3 = !bs6.isViewBlocking(world, mutable) || bs6.getLightBlock() == 0;
+        boolean bl3 = !bs6.isViewBlocking(world, mutable) || bs6.getLightDampening() == 0;
         BlockState bs7 = world.getBlockState(mutable.setWithOffset(blockPos, nd.corners[2]).move(face));
-        boolean bl4 = !bs7.isViewBlocking(world, mutable) || bs7.getLightBlock() == 0;
+        boolean bl4 = !bs7.isViewBlocking(world, mutable) || bs7.getLightDampening() == 0;
         BlockState bs8 = world.getBlockState(mutable.setWithOffset(blockPos, nd.corners[3]).move(face));
-        boolean bl5 = !bs8.isViewBlocking(world, mutable) || bs8.getLightBlock() == 0;
+        boolean bl5 = !bs8.isViewBlocking(world, mutable) || bs8.getLightDampening() == 0;
 
         float n;
         int o;
@@ -173,7 +173,7 @@ public class AOProcessorModern extends AOProcessor
             this.fs[translation.vert3] = aa;
         }
 
-	    float x = world.getShade(face, hasShade);
+	    float x = hasShade ? world.cardinalLighting().byFace(face) : 1.0F;
 
         for (int av = 0; av < this.fs.length; av++)
         {

--- a/src/main/java/fi/dy/masa/litematica/scheduler/tasks/TaskBase.java
+++ b/src/main/java/fi/dy/masa/litematica/scheduler/tasks/TaskBase.java
@@ -112,11 +112,11 @@ public abstract class TaskBase implements ITask, IInfoHudRenderer
     {
         if (radius <= 0)
         {
-            return WorldUtils.isClientChunkLoaded(world, pos.x, pos.z);
+            return WorldUtils.isClientChunkLoaded(world, pos.x(), pos.z());
         }
 
-        int chunkX = pos.x;
-        int chunkZ = pos.z;
+        int chunkX = pos.x();
+        int chunkZ = pos.z();
 
         for (int cx = chunkX - radius; cx <= chunkX + radius; ++cx)
         {
@@ -153,7 +153,7 @@ public abstract class TaskBase implements ITask, IInfoHudRenderer
             for (int i = 0; i < maxLines; ++i)
             {
                 ChunkPos pos = list.get(i);
-                this.infoHudLines.add(String.format("cx: %5d, cz: %5d (x: %d, z: %d)", pos.x, pos.z, pos.x << 4, pos.z << 4));
+                this.infoHudLines.add(String.format("cx: %5d, cz: %5d (x: %d, z: %d)", pos.x(), pos.z(), pos.x() << 4, pos.z() << 4));
             }
         }
     }

--- a/src/main/java/fi/dy/masa/litematica/scheduler/tasks/TaskDeleteBlocksByPlacement.java
+++ b/src/main/java/fi/dy/masa/litematica/scheduler/tasks/TaskDeleteBlocksByPlacement.java
@@ -74,7 +74,7 @@ public class TaskDeleteBlocksByPlacement extends TaskProcessChunkMultiPhase
         {
             int count = 0;
 
-            for (IntBoundingBox box : placement.getBoxesWithinChunk(pos.x, pos.z).values())
+            for (IntBoundingBox box : placement.getBoxesWithinChunk(pos.x(), pos.z()).values())
             {
                 box = PositionUtils.getClampedBox(box, range);
 
@@ -252,7 +252,7 @@ public class TaskDeleteBlocksByPlacement extends TaskProcessChunkMultiPhase
     @Override
     protected boolean canProcessChunk(ChunkPos pos)
     {
-        if (this.schematicWorld.getChunkSource().hasChunk(pos.x, pos.z) == false)
+        if (this.schematicWorld.getChunkSource().hasChunk(pos.x(), pos.z()) == false)
         {
             return false;
         }

--- a/src/main/java/fi/dy/masa/litematica/scheduler/tasks/TaskPasteSchematicPerChunkBase.java
+++ b/src/main/java/fi/dy/masa/litematica/scheduler/tasks/TaskPasteSchematicPerChunkBase.java
@@ -68,7 +68,7 @@ public abstract class TaskPasteSchematicPerChunkBase extends TaskProcessChunkMul
         {
             int count = 0;
 
-            for (IntBoundingBox box : placement.getBoxesWithinChunk(pos.x, pos.z).values())
+            for (IntBoundingBox box : placement.getBoxesWithinChunk(pos.x(), pos.z()).values())
             {
                 box = PositionUtils.getClampedBox(box, range);
 
@@ -101,7 +101,7 @@ public abstract class TaskPasteSchematicPerChunkBase extends TaskProcessChunkMul
     @Override
     protected boolean canProcessChunk(ChunkPos pos)
     {
-        if (this.schematicWorld.getChunkSource().hasChunk(pos.x, pos.z) == false ||
+        if (this.schematicWorld.getChunkSource().hasChunk(pos.x(), pos.z()) == false ||
 //            DataManager.getSchematicPlacementManager().hasPendingRebuildFor(pos))
             PlacementManagerDaemonHandler.INSTANCE.hasAnyRebuildTasksFor(pos))
         {

--- a/src/main/java/fi/dy/masa/litematica/scheduler/tasks/TaskPasteSchematicPerChunkCommand.java
+++ b/src/main/java/fi/dy/masa/litematica/scheduler/tasks/TaskPasteSchematicPerChunkCommand.java
@@ -192,9 +192,9 @@ public class TaskPasteSchematicPerChunkCommand extends TaskPasteSchematicPerChun
     {
         ChunkPos chunkPos = this.currentChunkPos;
         if (chunkPos == null || this.positionIterator == null || this.mc.level == null) return;
-        ChunkSchematic schematicChunk = this.schematicWorld.getChunkSource().getChunkForLighting(chunkPos.x, chunkPos.z);
+        ChunkSchematic schematicChunk = this.schematicWorld.getChunkSource().getChunkForLighting(chunkPos.x(), chunkPos.z());
         if (schematicChunk == null || this.currentBox == null) return;
-        ChunkAccess clientChunk = this.mc.level.getChunk(chunkPos.x, chunkPos.z);
+        ChunkAccess clientChunk = this.mc.level.getChunk(chunkPos.x(), chunkPos.z());
         boolean ignoreLimit = Configs.Generic.PASTE_IGNORE_CMD_LIMIT.getBooleanValue();
 
         while (this.positionIterator.hasNext() &&
@@ -224,10 +224,10 @@ public class TaskPasteSchematicPerChunkCommand extends TaskPasteSchematicPerChun
     {
         ChunkPos chunkPos = this.currentChunkPos;
         if (chunkPos == null || this.currentBox == null || this.mc.level == null) return;
-        final int baseX = chunkPos.x << 4;
-        final int baseZ = chunkPos.z << 4;
-        ChunkSchematic schematicChunk = this.schematicWorld.getChunkSource().getChunkForLighting(chunkPos.x, chunkPos.z);
-        ChunkAccess clientChunk = this.mc.level.getChunk(chunkPos.x, chunkPos.z);
+        final int baseX = chunkPos.x() << 4;
+        final int baseZ = chunkPos.z() << 4;
+        ChunkSchematic schematicChunk = this.schematicWorld.getChunkSource().getChunkForLighting(chunkPos.x(), chunkPos.z());
+        ChunkAccess clientChunk = this.mc.level.getChunk(chunkPos.x(), chunkPos.z());
 
         while (this.fillVolumes.isEmpty() == false && this.queuedCommands.size() < this.maxCommandsPerTick)
         {

--- a/src/main/java/fi/dy/masa/litematica/scheduler/tasks/TaskSaveSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/scheduler/tasks/TaskSaveSchematic.java
@@ -58,7 +58,7 @@ public class TaskSaveSchematic extends TaskProcessChunkBase
     {
         if (this.fromSchematicWorld)
         {
-            return this.schematicWorld != null && this.schematicWorld.getChunkSource().hasChunk(pos.x, pos.z);
+            return this.schematicWorld != null && this.schematicWorld.getChunkSource().hasChunk(pos.x(), pos.z());
         }
 
         // Request entity data from Servux, if the ClientWorld matches, and treat it as not yet loaded
@@ -72,7 +72,7 @@ public class TaskSaveSchematic extends TaskProcessChunkBase
             }
             else if (EntitiesDataStorage.getInstance().hasPendingChunk(pos) == false)
             {
-                ImmutableMap<@NotNull String, @NotNull IntBoundingBox> volumes = PositionUtils.getBoxesWithinChunk(pos.x, pos.z, this.subRegions);
+                ImmutableMap<@NotNull String, @NotNull IntBoundingBox> volumes = PositionUtils.getBoxesWithinChunk(pos.x(), pos.z(), this.subRegions);
                 int minY = 319;         // Invert Values
                 int maxY = -60;
 
@@ -104,12 +104,12 @@ public class TaskSaveSchematic extends TaskProcessChunkBase
     protected boolean processChunk(ChunkPos pos)
     {
         Level world = this.fromSchematicWorld ? this.schematicWorld : this.world;
-        ImmutableMap<@NotNull String, @NotNull IntBoundingBox> volumes = PositionUtils.getBoxesWithinChunk(pos.x, pos.z, this.subRegions);
+        ImmutableMap<@NotNull String, @NotNull IntBoundingBox> volumes = PositionUtils.getBoxesWithinChunk(pos.x(), pos.z(), this.subRegions);
         this.schematic.takeBlocksFromWorldWithinChunk(world, volumes, this.subRegions, this.info);
 
         if (this.info.ignoreEntities == false)
         {
-            this.schematic.takeEntitiesFromWorldWithinChunk(world, pos.x, pos.z, volumes, this.subRegions, this.existingEntities, this.origin);
+            this.schematic.takeEntitiesFromWorldWithinChunk(world, pos.x(), pos.z(), volumes, this.subRegions, this.existingEntities, this.origin);
         }
 
         if ((EntitiesDataStorage.getInstance().hasServuxServer() ||

--- a/src/main/java/fi/dy/masa/litematica/schematic/LitematicaSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/schematic/LitematicaSchematic.java
@@ -926,7 +926,7 @@ public class LitematicaSchematic
         {
             for (int cz = minCZ; cz <= maxCZ; ++cz)
             {
-                long cp = ChunkPos.asLong(cx, cz);
+                long cp = ChunkPos.pack(cx, cz);
 
                 LevelChunkTicks<T> chunkTickScheduler = chunkTickSchedulers.get(cp);
 

--- a/src/main/java/fi/dy/masa/litematica/schematic/conversion/SchematicConversionFixers.java
+++ b/src/main/java/fi/dy/masa/litematica/schematic/conversion/SchematicConversionFixers.java
@@ -160,7 +160,7 @@ public class SchematicConversionFixers
 
     public static final IStateFixer FIXER_DIRT_SNOWY = (reader, state, pos) -> {
         Block block = reader.getBlockState(pos.above()).getBlock();
-        return state.setValue(SnowyDirtBlock.SNOWY, (block == Blocks.SNOW_BLOCK || block == Blocks.SNOW));
+        return state.setValue(SnowyBlock.SNOWY, (block == Blocks.SNOW_BLOCK || block == Blocks.SNOW));
     };
 
     public static final IStateFixer FIXER_DOOR = (reader, state, pos) -> {

--- a/src/main/java/fi/dy/masa/litematica/schematic/conversion/SchematicConverter.java
+++ b/src/main/java/fi/dy/masa/litematica/schematic/conversion/SchematicConverter.java
@@ -230,7 +230,7 @@ public class SchematicConverter
         this.fixersPerBlock.put(IronBarsBlock.class,                    SchematicConversionFixers.FIXER_PANE); // Iron Bars & Glass Pane
         this.fixersPerBlock.put(RepeaterBlock.class,                SchematicConversionFixers.FIXER_REDSTONE_REPEATER);
         this.fixersPerBlock.put(RedStoneWireBlock.class,            SchematicConversionFixers.FIXER_REDSTONE_WIRE);
-        this.fixersPerBlock.put(SnowyDirtBlock.class,                   SchematicConversionFixers.FIXER_DIRT_SNOWY); // Podzol
+        this.fixersPerBlock.put(SnowyBlock.class,                   SchematicConversionFixers.FIXER_DIRT_SNOWY); // Podzol
         this.fixersPerBlock.put(StemBlock.class,                    SchematicConversionFixers.FIXER_STEM);
         this.fixersPerBlock.put(StainedGlassPaneBlock.class,        SchematicConversionFixers.FIXER_PANE);
         this.fixersPerBlock.put(StairBlock.class,                  SchematicConversionFixers.FIXER_STAIRS);

--- a/src/main/java/fi/dy/masa/litematica/schematic/placement/PlacementManagerDaemonHandler.java
+++ b/src/main/java/fi/dy/masa/litematica/schematic/placement/PlacementManagerDaemonHandler.java
@@ -368,7 +368,7 @@ public class PlacementManagerDaemonHandler implements IThreadDaemonHandler<Place
 
 	public boolean hasAnyRebuildTasksFor(ChunkPos pos)
 	{
-		return this.hasAnyRebuildTasksFor(pos.x, pos.z);
+		return this.hasAnyRebuildTasksFor(pos.x(), pos.z());
 	}
 
 	public synchronized boolean hasAnyUnloadTasksFor(int cx, int cz)

--- a/src/main/java/fi/dy/masa/litematica/schematic/placement/PlacementManagerTask.java
+++ b/src/main/java/fi/dy/masa/litematica/schematic/placement/PlacementManagerTask.java
@@ -22,17 +22,17 @@ public abstract class PlacementManagerTask extends DefaultThreadTaskBase
 		this.chunkX = chunkX;
 		this.chunkZ = chunkZ;
 		this.chunkPos = new ChunkPos(chunkX, chunkZ);
-		this.chunkLong = this.chunkPos.toLong();
+		this.chunkLong = this.chunkPos.pack();
 	}
 
 	protected PlacementManagerTask(Supplier<WorldSchematic> worldSupplier, ChunkPos chunkPos)
 	{
 		super();
 		this.worldSupplier = worldSupplier;
-		this.chunkX = chunkPos.x;
-		this.chunkZ = chunkPos.z;
+		this.chunkX = chunkPos.x();
+		this.chunkZ = chunkPos.z();
 		this.chunkPos = chunkPos;
-		this.chunkLong = chunkPos.toLong();
+		this.chunkLong = chunkPos.pack();
 	}
 
 	protected PlacementManagerTask(Supplier<WorldSchematic> worldSupplier, Long longPos)

--- a/src/main/java/fi/dy/masa/litematica/schematic/placement/SchematicPlacementManager.java
+++ b/src/main/java/fi/dy/masa/litematica/schematic/placement/SchematicPlacementManager.java
@@ -209,15 +209,15 @@ public class SchematicPlacementManager
         }
 
         PlacementManagerDaemonHandler.INSTANCE.addTask(
-                new PlacementManagerTaskOther(this.worldSupplier, cc.x, cc.z, () ->
+                new PlacementManagerTaskOther(this.worldSupplier, cc.x(), cc.z(), () ->
                 {
                     Set<ChunkPos> loaded = new HashSet<>();
                     Set<ChunkPos> notLoaded = new HashSet<>();
 
-                    final int startcx = cc.x - offset;
-                    final int startcz = cc.z - offset;
-                    final int endcx = cc.x + offset;
-                    final int endcz = cc.z + offset;
+                    final int startcx = cc.x() - offset;
+                    final int startcz = cc.z() - offset;
+                    final int endcx = cc.x() + offset;
+                    final int endcz = cc.z() + offset;
 
                     for (int cx = startcx; cx < endcx; cx++)
                     {
@@ -228,7 +228,7 @@ public class SchematicPlacementManager
                             if (!this.worldSupplier.get().getChunkSource().hasChunk(cx, cz) &&
                                 DataManager.getSchematicPlacementManager().canHandleChunk(Minecraft.getInstance().level, cx, cz))
                             {
-                                Frustum frustum = Minecraft.getInstance().levelRenderer.getCapturedFrustum();
+                                Frustum frustum = null; // getCapturedFrustum() removed in 26.1.x
 
                                 // Check Frustum culling
                                 if (frustum != null)
@@ -263,13 +263,13 @@ public class SchematicPlacementManager
                         loaded.forEach(c ->
                                        {
                                            PlacementManagerDaemonHandler.INSTANCE.addTask(
-                                                   new PlacementManagerTaskOther(this.worldSupplier, c.x, c.z, () ->
+                                                   new PlacementManagerTaskOther(this.worldSupplier, c.x(), c.z(), () ->
                                                    {
                                                        List<SchematicPlacement> placements = DataManager.getSchematicPlacementManager().getAllSchematicsTouchingChunk(c);
 
                                                        if (placements.isEmpty())
                                                        {
-                                                           DataManager.getSchematicPlacementManager().markChunkForUnload(c.x, c.z);
+                                                           DataManager.getSchematicPlacementManager().markChunkForUnload(c.x(), c.z());
                                                        }
                                                        else
                                                        {
@@ -285,7 +285,7 @@ public class SchematicPlacementManager
 
                                                            if (unload)
                                                            {
-                                                               DataManager.getSchematicPlacementManager().markChunkForUnload(c.x, c.z);
+                                                               DataManager.getSchematicPlacementManager().markChunkForUnload(c.x(), c.z());
                                                            }
                                                        }
                                                    }));
@@ -298,14 +298,14 @@ public class SchematicPlacementManager
                         notLoaded.forEach(c ->
                                           {
                                               PlacementManagerDaemonHandler.INSTANCE.addTask(
-                                                      new PlacementManagerTaskOther(this.worldSupplier, c.x, c.z, () ->
+                                                      new PlacementManagerTaskOther(this.worldSupplier, c.x(), c.z(), () ->
                                                       {
                                                           List<SchematicPlacement> placements = DataManager.getSchematicPlacementManager().getAllSchematicsTouchingChunk(c);
 
                                                           // Load/Rebuild if Chunk is Near, no matter what for Verifier.
                                                           if (c.getChessboardDistance(cc) <= 3)
                                                           {
-                                                              DataManager.getSchematicPlacementManager().markChunkForRebuild(c.x, c.z);
+                                                              DataManager.getSchematicPlacementManager().markChunkForRebuild(c.x(), c.z());
                                                           }
                                                           else
                                                           {
@@ -323,7 +323,7 @@ public class SchematicPlacementManager
 
                                                                   if (rebuild)
                                                                   {
-                                                                      DataManager.getSchematicPlacementManager().markChunkForRebuild(c.x, c.z);
+                                                                      DataManager.getSchematicPlacementManager().markChunkForRebuild(c.x(), c.z());
                                                                   }
                                                               }
                                                           }
@@ -404,7 +404,7 @@ public class SchematicPlacementManager
 
                             for (ChunkPos cp : touchedChunks)
                             {
-                                if (this.canHandleChunk(Minecraft.getInstance().level, cp.x, cp.z))
+                                if (this.canHandleChunk(Minecraft.getInstance().level, cp.x(), cp.z()))
                                 {
                                     shouldRender.set(true);
                                     break;
@@ -424,7 +424,7 @@ public class SchematicPlacementManager
 
     public boolean checkIfChunkShouldRender(ChunkPos chunkPos)
     {
-        return this.checkIfChunkShouldRender(chunkPos.x, chunkPos.z);
+        return this.checkIfChunkShouldRender(chunkPos.x(), chunkPos.z());
     }
 
     public boolean checkIfChunkShouldRender(int chunkX, int chunkZ)
@@ -489,9 +489,9 @@ public class SchematicPlacementManager
 
                     if (range.intersectsBox(minX, minY, minZ, maxX, maxY, maxZ))
                     {
-                        ChunkPos pos = new ChunkPos(posLong);
+                        ChunkPos pos = ChunkPos.unpack(posLong);
 
-                        if (worldSchematic.getChunkSource().getChunkState(pos.x, pos.z).atLeast(ChunkSchematicState.LOADED))
+                        if (worldSchematic.getChunkSource().getChunkState(pos.x(), pos.z()).atLeast(ChunkSchematicState.LOADED))
                         {
                             this.visibleChunks.add(pos);
                         }
@@ -525,17 +525,17 @@ public class SchematicPlacementManager
 
     public List<PlacementPart> getPlacementPartsInChunk(int chunkX, int chunkZ)
     {
-        return this.touchedVolumesInChunk.getOrDefault(ChunkPos.asLong(chunkX, chunkZ), Collections.emptyList());
+        return this.touchedVolumesInChunk.getOrDefault(ChunkPos.pack(chunkX, chunkZ), Collections.emptyList());
     }
 
     public List<PlacementPart> getAllPlacementsTouchingChunk(BlockPos pos)
     {
-        return this.touchedVolumesInChunk.getOrDefault(ChunkPos.asLong(pos.getX() >> 4, pos.getZ() >> 4), Collections.emptyList());
+        return this.touchedVolumesInChunk.getOrDefault(ChunkPos.pack(pos.getX() >> 4, pos.getZ() >> 4), Collections.emptyList());
     }
 
     public int getPlacementPartsInChunkCount(int chunkX, int chunkZ)
     {
-        long longPos = ChunkPos.asLong(chunkX, chunkZ);
+        long longPos = ChunkPos.pack(chunkX, chunkZ);
 
         if (this.touchedVolumesInChunk.containsKey(longPos))
         {
@@ -734,7 +734,7 @@ public class SchematicPlacementManager
                 this.updateTouchedBoxesInChunk(pos);
             }
 
-            PlacementManagerDaemonHandler.INSTANCE.removeUnloadTasksFor(pos.x, pos.z);
+            PlacementManagerDaemonHandler.INSTANCE.removeUnloadTasksFor(pos.x(), pos.z());
         }
 
         this.markChunksForRebuild(placement);
@@ -822,7 +822,7 @@ public class SchematicPlacementManager
 
     protected void updateTouchedBoxesInChunk(ChunkPos pos)
     {
-        long chunkPosLong = pos.toLong();
+        long chunkPosLong = pos.pack();
         this.touchedVolumesInChunk.remove(chunkPosLong);
 
         Collection<SchematicPlacement> placements = this.schematicsTouchingChunk.get(pos);
@@ -836,7 +836,7 @@ public class SchematicPlacementManager
                     continue;
                 }
 
-                Map<String, IntBoundingBox> boxMap = placement.getBoxesWithinChunk(pos.x, pos.z);
+                Map<String, IntBoundingBox> boxMap = placement.getBoxesWithinChunk(pos.x(), pos.z());
 
                 if (boxMap.isEmpty() == false)
                 {
@@ -874,7 +874,7 @@ public class SchematicPlacementManager
 
     public void markChunkForUnload(ChunkPos pos)
     {
-        this.markChunkForUnload(pos.x, pos.z);
+        this.markChunkForUnload(pos.x(), pos.z());
     }
 
     private void markChunksForUnload(Collection<ChunkPos> chunks)
@@ -904,7 +904,7 @@ public class SchematicPlacementManager
 
     public void markChunkForRebuild(ChunkPos pos)
     {
-        this.markChunkForRebuild(pos.x, pos.z);
+        this.markChunkForRebuild(pos.x(), pos.z());
     }
 
     public void markChunkForRebuild(int cx, int cz)
@@ -1086,22 +1086,22 @@ public class SchematicPlacementManager
                 final int partsCount = this.getPlacementPartsInChunkCount(cx, cz);
                 final boolean tasks = PlacementManagerDaemonHandler.INSTANCE.hasAnyTasksFor(cx, cz);
 
-                chat.addMessage(
+                chat.addClientSystemMessage(
                         StringUtils.translateAsText(PmCommand.PREFIX+".display_chunk_debug.base", cx, cz, chunk.getState(), timeCreated)
                 );
-                chat.addMessage(
+                chat.addClientSystemMessage(
                         StringUtils.translateAsText(PmCommand.PREFIX+".display_chunk_debug.entities", entCount, teCount)
                 );
-                chat.addMessage(
+                chat.addClientSystemMessage(
                         StringUtils.translateAsText(PmCommand.PREFIX+".display_chunk_debug.sections", sectCount, height, minY)
                 );
-                chat.addMessage(
+                chat.addClientSystemMessage(
                         StringUtils.translateAsText(PmCommand.PREFIX+".display_chunk_debug.schematics", schemCount, partsCount, tasks)
                 );
             }
             else
             {
-                chat.addMessage(
+                chat.addClientSystemMessage(
                         StringUtils.translateAsText(PmCommand.PREFIX+".display_chunk_debug.not_loaded", cx, cz)
                 );
             }
@@ -1112,7 +1112,7 @@ public class SchematicPlacementManager
     {
         if (this.worldSupplier.get() != null)
         {
-            chat.addMessage(
+            chat.addClientSystemMessage(
                     StringUtils.translateAsText(PmCommand.PREFIX+".mark_chunk_for_rebuild", cx, cz)
             );
 

--- a/src/main/java/fi/dy/masa/litematica/schematic/verifier/SchematicVerifier.java
+++ b/src/main/java/fi/dy/masa/litematica/schematic/verifier/SchematicVerifier.java
@@ -477,9 +477,9 @@ public class SchematicVerifier extends TaskBase implements IInfoHudRenderer
                 ChunkPos pos = iter.next();
                 int count = 0;
 
-                for (int cx = pos.x - 1; cx <= pos.x + 1; ++cx)
+                for (int cx = pos.x() - 1; cx <= pos.x() + 1; ++cx)
                 {
-                    for (int cz = pos.z - 1; cz <= pos.z + 1; ++cz)
+                    for (int cz = pos.z() - 1; cz <= pos.z() + 1; ++cz)
                     {
                         if (WorldUtils.isClientChunkLoaded(this.worldClient, cx, cz))
                         {
@@ -489,11 +489,11 @@ public class SchematicVerifier extends TaskBase implements IInfoHudRenderer
                 }
 
                 // Require the surrounding chunks in the client world to be loaded as well
-                if (count == 9 && this.worldSchematic.getChunkSource().hasChunk(pos.x, pos.z))
+                if (count == 9 && this.worldSchematic.getChunkSource().hasChunk(pos.x(), pos.z()))
                 {
-                    ChunkAccess chunkClient = this.worldClient.getChunk(pos.x, pos.z);
-                    ChunkAccess chunkSchematic = this.worldSchematic.getChunk(pos.x, pos.z);
-                    Map<String, IntBoundingBox> boxes = this.schematicPlacement.getBoxesWithinChunk(pos.x, pos.z);
+                    ChunkAccess chunkClient = this.worldClient.getChunk(pos.x(), pos.z());
+                    ChunkAccess chunkSchematic = this.worldSchematic.getChunk(pos.x(), pos.z());
+                    Map<String, IntBoundingBox> boxes = this.schematicPlacement.getBoxesWithinChunk(pos.x(), pos.z());
 
                     for (IntBoundingBox box : boxes.values())
                     {

--- a/src/main/java/fi/dy/masa/litematica/util/EntityUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/EntityUtils.java
@@ -439,12 +439,12 @@ public class EntityUtils
         entity.setGlowingTag(nbt.getBooleanOr("Glowing", false));
         entity.setTicksFrozen(nbt.getIntOr("TicksFrozen", 0));
         if (nbt.contains("Tags")) {
-            entity.getTags().clear();
+            entity.entityTags().clear();
             ListTag nbtList4 = nbt.getListOrEmpty("Tags");
             int max = Math.min(nbtList4.size(), 1024);
 
             for(int i = 0; i < max; ++i) {
-                entity.getTags().add(nbtList4.getStringOr(i, ""));
+                entity.entityTags().add(nbtList4.getStringOr(i, ""));
             }
         }
 

--- a/src/main/java/fi/dy/masa/litematica/util/InventoryUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/InventoryUtils.java
@@ -13,7 +13,7 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.inventory.ClickType;
+import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
@@ -662,8 +662,8 @@ public class InventoryUtils
                     //clickSlot(container, slot, button, ClickType.PICKUP);
                     //clickSlot(container, currentSlot, 0, ClickType.PICKUP);
 
-                    mc.gameMode.handleInventoryMouseClick(handler.containerId, slot.index, button, ClickType.PICKUP, player);
-                    mc.gameMode.handleInventoryMouseClick(handler.containerId, currentSlot, 0, ClickType.PICKUP, player);
+                    mc.gameMode.handleContainerInput(handler.containerId, slot.index, button, ContainerInput.PICKUP, player);
+                    mc.gameMode.handleContainerInput(handler.containerId, currentSlot, 0, ContainerInput.PICKUP, player);
 
                     break;
                 }

--- a/src/main/java/fi/dy/masa/litematica/util/PositionUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/PositionUtils.java
@@ -72,7 +72,7 @@ public class PositionUtils
 
     public static long getChunkPosLong(BlockPos blockPos)
     {
-        return ChunkPos.asLong(blockPos.getX() >> 4, blockPos.getZ() >> 4);
+        return ChunkPos.pack(blockPos.getX() >> 4, blockPos.getZ() >> 4);
     }
 
     public static BlockPos getMinCorner(BlockPos pos1, BlockPos pos2)
@@ -1202,8 +1202,8 @@ public class PositionUtils
 
         private double distanceSq(ChunkPos pos)
         {
-            double dx = (double) (pos.x << 4) - this.posReference.getX();
-            double dz = (double) (pos.z << 4) - this.posReference.getZ();
+            double dx = (double) (pos.x() << 4) - this.posReference.getX();
+            double dz = (double) (pos.z() << 4) - this.posReference.getZ();
 
             return dx * dx + dz * dz;
         }
@@ -1221,11 +1221,11 @@ public class PositionUtils
         @Override
         public int compare(ChunkPos pos1, ChunkPos pos2)
         {
-            int refX = this.referencePosition.x;
-            int refZ = this.referencePosition.z;
+            int refX = this.referencePosition.x();
+            int refZ = this.referencePosition.z();
 
-            double dist1 = (refX - pos1.x) * (refX - pos1.x) + (refZ - pos1.z) * (refZ - pos1.z);
-            double dist2 = (refX - pos2.x) * (refX - pos2.x) + (refZ - pos2.z) * (refZ - pos2.z);
+            double dist1 = (refX - pos1.x()) * (refX - pos1.x()) + (refZ - pos1.z()) * (refZ - pos1.z());
+            double dist2 = (refX - pos2.x()) * (refX - pos2.x()) + (refZ - pos2.z()) * (refZ - pos2.z());
 
             return Double.compare(dist1, dist2);
         }

--- a/src/main/java/fi/dy/masa/litematica/util/SchematicPlacingUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/SchematicPlacingUtils.java
@@ -54,7 +54,7 @@ public class SchematicPlacingUtils
                                                   boolean notifyNeighbors)
     {
         LitematicaSchematic schematic = schematicPlacement.getSchematic();
-        Set<String> regionsTouchingChunk = schematicPlacement.getRegionsTouchingChunk(chunkPos.x, chunkPos.z);
+        Set<String> regionsTouchingChunk = schematicPlacement.getRegionsTouchingChunk(chunkPos.x(), chunkPos.z());
         BlockPos origin = schematicPlacement.getOrigin();
         boolean allSuccess = true;
 
@@ -129,7 +129,7 @@ public class SchematicPlacingUtils
                                                  PasteLayerBehavior layerBehavior,
                                                  boolean notifyNeighbors)
     {
-        IntBoundingBox bounds = schematicPlacement.getBoxWithinChunkForRegion(regionName, chunkPos.x, chunkPos.z);
+        IntBoundingBox bounds = schematicPlacement.getBoxWithinChunkForRegion(regionName, chunkPos.x(), chunkPos.z());
         Vec3i regionSize = schematicPlacement.getSchematic().getAreaSizeAsVec3i(regionName);
 
         if (bounds == null || container == null || blockEntityMap == null || regionSize == null)
@@ -318,9 +318,9 @@ public class SchematicPlacingUtils
 
         if (world instanceof WorldSchematic ws)
         {
-            if (!ws.getChunk(chunkPos.x, chunkPos.z).getState().atLeast(ChunkSchematicState.FILLED))
+            if (!ws.getChunk(chunkPos.x(), chunkPos.z()).getState().atLeast(ChunkSchematicState.FILLED))
             {
-                ws.getChunkSource().setChunkState(chunkPos.x, chunkPos.z, ChunkSchematicState.FILLED);
+                ws.getChunkSource().setChunkState(chunkPos.x(), chunkPos.z(), ChunkSchematicState.FILLED);
             }
         }
 
@@ -435,10 +435,10 @@ public class SchematicPlacingUtils
         final int offX = regionPosRelTransformed.getX() + origin.getX();
         final int offY = regionPosRelTransformed.getY() + origin.getY();
         final int offZ = regionPosRelTransformed.getZ() + origin.getZ();
-        final double minX = (chunkPos.x << 4);
-        final double minZ = (chunkPos.z << 4);
-        final double maxX = (chunkPos.x << 4) + 16;
-        final double maxZ = (chunkPos.z << 4) + 16;
+        final double minX = (chunkPos.x() << 4);
+        final double minZ = (chunkPos.z() << 4);
+        final double maxX = (chunkPos.x() << 4) + 16;
+        final double maxZ = (chunkPos.z() << 4) + 16;
 
         final Rotation rotationCombined = schematicPlacement.getRotation().getRotated(placement.getRotation());
         final Mirror mirrorMain = schematicPlacement.getMirror();

--- a/src/main/java/fi/dy/masa/litematica/util/SchematicWorldRefresher.java
+++ b/src/main/java/fi/dy/masa/litematica/util/SchematicWorldRefresher.java
@@ -53,10 +53,10 @@ public class SchematicWorldRefresher implements IRangeChangeListener
 
                 // && chunk.isEmpty() == false
                 // Only mark chunks that are actually rendered (if the schematic world contains more chunks)
-                if (pos.x >= cxMin && pos.x <= cxMax &&
-                    WorldUtils.isClientChunkLoaded(this.mc.level, pos.x, pos.z))
+                if (pos.x() >= cxMin && pos.x() <= cxMax &&
+                    WorldUtils.isClientChunkLoaded(this.mc.level, pos.x(), pos.z()))
                 {
-                    world.scheduleChunkRenders(pos.x, pos.z);
+                    world.scheduleChunkRenders(pos.x(), pos.z());
                 }
             }
         }
@@ -79,9 +79,9 @@ public class SchematicWorldRefresher implements IRangeChangeListener
 //                ChunkPos pos = chunk.getPos();
                 // chunk.isEmpty() == false &&
                 // Only mark chunks that are actually rendered (if the schematic world contains more chunks)
-                if (WorldUtils.isClientChunkLoaded(this.mc.level, pos.x, pos.z))
+                if (WorldUtils.isClientChunkLoaded(this.mc.level, pos.x(), pos.z()))
                 {
-                    world.scheduleChunkRenders(pos.x, pos.z);
+                    world.scheduleChunkRenders(pos.x(), pos.z());
                 }
             }
         }
@@ -107,10 +107,10 @@ public class SchematicWorldRefresher implements IRangeChangeListener
 
                 //  && chunk.isEmpty() == false
                 // Only mark chunks that are actually rendered (if the schematic world contains more chunks)
-                if (pos.z >= czMin && pos.z <= czMax &&
-                    WorldUtils.isClientChunkLoaded(this.mc.level, pos.x, pos.z))
+                if (pos.z() >= czMin && pos.z() <= czMax &&
+                    WorldUtils.isClientChunkLoaded(this.mc.level, pos.x(), pos.z()))
                 {
-                    world.scheduleChunkRenders(pos.x, pos.z);
+                    world.scheduleChunkRenders(pos.x(), pos.z());
                 }
             }
         }

--- a/src/main/java/fi/dy/masa/litematica/util/WorldPlacingUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/WorldPlacingUtils.java
@@ -45,7 +45,7 @@ public class WorldPlacingUtils
     {
         ProtoChunkSchematic filledChunk = null;
         LitematicaSchematic schematic = schematicPlacement.getSchematic();
-        Set<String> regionsTouchingChunk = schematicPlacement.getRegionsTouchingChunk(chunkPos.x, chunkPos.z);
+        Set<String> regionsTouchingChunk = schematicPlacement.getRegionsTouchingChunk(chunkPos.x(), chunkPos.z());
         BlockPos origin = schematicPlacement.getOrigin();
         boolean allSuccess = true;
 
@@ -104,7 +104,7 @@ public class WorldPlacingUtils
                                                               SchematicPlacement schematicPlacement,
                                                               SubRegionPlacement placement)
     {
-        IntBoundingBox bounds = schematicPlacement.getBoxWithinChunkForRegion(regionName, chunkPos.x, chunkPos.z);
+        IntBoundingBox bounds = schematicPlacement.getBoxWithinChunkForRegion(regionName, chunkPos.x(), chunkPos.z());
         Vec3i regionSize = schematicPlacement.getSchematic().getAreaSizeAsVec3i(regionName);
 
         if (bounds == null || container == null || blockEntityMap == null || regionSize == null)
@@ -314,10 +314,10 @@ public class WorldPlacingUtils
         final int offX = regionPosRelTransformed.getX() + origin.getX();
         final int offY = regionPosRelTransformed.getY() + origin.getY();
         final int offZ = regionPosRelTransformed.getZ() + origin.getZ();
-        final double minX = (chunkPos.x << 4);
-        final double minZ = (chunkPos.z << 4);
-        final double maxX = (chunkPos.x << 4) + 16;
-        final double maxZ = (chunkPos.z << 4) + 16;
+        final double minX = (chunkPos.x() << 4);
+        final double minZ = (chunkPos.z() << 4);
+        final double maxX = (chunkPos.x() << 4) + 16;
+        final double maxZ = (chunkPos.z() << 4) + 16;
 
         final Rotation rotationCombined = schematicPlacement.getRotation().getRotated(placement.getRotation());
         final Mirror mirrorMain = schematicPlacement.getMirror();

--- a/src/main/java/fi/dy/masa/litematica/world/ChunkManagerSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/world/ChunkManagerSchematic.java
@@ -44,18 +44,18 @@ public class ChunkManagerSchematic extends ChunkSource
     {
         ChunkSchematic chunk = new ChunkSchematic(this.world, new ChunkPos(chunkX, chunkZ));
         chunk.setState(ChunkSchematicState.LOADED);
-        this.loadedChunks.put(ChunkPos.asLong(chunkX, chunkZ), chunk);
+        this.loadedChunks.put(ChunkPos.pack(chunkX, chunkZ), chunk);
     }
 
     @Override
     public synchronized boolean hasChunk(int chunkX, int chunkZ)
     {
-        return this.loadedChunks.containsKey(ChunkPos.asLong(chunkX, chunkZ));
+        return this.loadedChunks.containsKey(ChunkPos.pack(chunkX, chunkZ));
     }
 
     public synchronized ChunkSchematicState getChunkState(int chunkX, int chunkZ)
     {
-        long key = ChunkPos.asLong(chunkX, chunkZ);
+        long key = ChunkPos.pack(chunkX, chunkZ);
 
         if (this.loadedChunks.containsKey(key))
         {
@@ -69,7 +69,7 @@ public class ChunkManagerSchematic extends ChunkSource
 
     public synchronized void setChunkState(int chunkX, int chunkZ, ChunkSchematicState state)
     {
-        long key = ChunkPos.asLong(chunkX, chunkZ);
+        long key = ChunkPos.pack(chunkX, chunkZ);
 
         if (this.loadedChunks.containsKey(key))
         {
@@ -122,19 +122,19 @@ public class ChunkManagerSchematic extends ChunkSource
     @Override
     public synchronized ChunkSchematic getChunkForLighting(int chunkX, int chunkZ)
     {
-        ChunkSchematic chunk = this.loadedChunks.get(ChunkPos.asLong(chunkX, chunkZ));
+        ChunkSchematic chunk = this.loadedChunks.get(ChunkPos.pack(chunkX, chunkZ));
         return chunk == null ? this.blankChunk : chunk;
     }
 
     @Nullable
     public synchronized ChunkSchematic getChunkIfExists(int chunkX, int chunkZ)
     {
-        return this.loadedChunks.get(ChunkPos.asLong(chunkX, chunkZ));
+        return this.loadedChunks.get(ChunkPos.pack(chunkX, chunkZ));
     }
 
     public synchronized void unloadChunk(int chunkX, int chunkZ)
     {
-        ChunkSchematic chunk = this.loadedChunks.remove(ChunkPos.asLong(chunkX, chunkZ));
+        ChunkSchematic chunk = this.loadedChunks.remove(ChunkPos.pack(chunkX, chunkZ));
 
         if (chunk != null)
         {
@@ -166,7 +166,7 @@ public class ChunkManagerSchematic extends ChunkSource
             newChunk.setState(ChunkSchematicState.LOADED);
         }
 
-        this.loadedChunks.put(ChunkPos.asLong(chunkX, chunkZ), newChunk);
+        this.loadedChunks.put(ChunkPos.pack(chunkX, chunkZ), newChunk);
         return true;
     }
 

--- a/src/main/java/fi/dy/masa/litematica/world/SchematicEntityLookup.java
+++ b/src/main/java/fi/dy/masa/litematica/world/SchematicEntityLookup.java
@@ -52,10 +52,10 @@ public class SchematicEntityLookup<T extends EntityAccess> implements LevelEntit
 
         synchronized (this.chunkMap)
         {
-            List<UUID> list = this.chunkMap.getOrDefault(pos.toLong(), new ArrayList<>());
+            List<UUID> list = this.chunkMap.getOrDefault(pos.pack(), new ArrayList<>());
 
             list.add(entity.getUUID());
-            this.chunkMap.put(pos.toLong(), list);
+            this.chunkMap.put(pos.pack(), list);
         }
 
         synchronized (this.uuidMap)
@@ -137,7 +137,7 @@ public class SchematicEntityLookup<T extends EntityAccess> implements LevelEntit
 
     protected synchronized int removeByChunk(ChunkPos pos)
     {
-        final Long longPos = pos.toLong();
+        final Long longPos = pos.pack();
         int count = 0;
 
         synchronized (this.chunkMap)
@@ -256,7 +256,7 @@ public class SchematicEntityLookup<T extends EntityAccess> implements LevelEntit
     {
         synchronized (this.chunkMap)
         {
-            final List<UUID> list = this.chunkMap.get(pos.toLong());
+            final List<UUID> list = this.chunkMap.get(pos.pack());
 
             if (list == null || list.isEmpty())
             {
@@ -366,7 +366,7 @@ public class SchematicEntityLookup<T extends EntityAccess> implements LevelEntit
 
     public synchronized boolean contains(ChunkPos pos)
     {
-        return this.chunkMap.containsKey(pos.toLong());
+        return this.chunkMap.containsKey(pos.pack());
     }
 
     protected void reset()

--- a/src/main/java/fi/dy/masa/litematica/world/WorldSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/world/WorldSchematic.java
@@ -25,6 +25,8 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
 import net.minecraft.util.random.WeightedList;
 import net.minecraft.world.TickRateManager;
+import net.minecraft.world.clock.ClockManager;
+import net.minecraft.world.level.CardinalLighting;
 import net.minecraft.world.attribute.EnvironmentAttributeSystem;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
@@ -60,12 +62,14 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.scores.Scoreboard;
 import net.minecraft.world.ticks.BlackholeTickAccess;
 import net.minecraft.world.ticks.LevelTickAccess;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
+import net.minecraft.world.level.ColorResolver;
 
 import fi.dy.masa.malilib.util.WorldUtils;
 import fi.dy.masa.litematica.Reference;
 import fi.dy.masa.litematica.render.IWorldSchematicRenderer;
 
-public class WorldSchematic extends Level
+public class WorldSchematic extends Level implements BlockAndTintGetter
 {
     protected static final ResourceKey<Level> REGISTRY_KEY = ResourceKey.create(Registries.DIMENSION, Identifier.fromNamespaceAndPath(Reference.MOD_ID, "schematic_world"));
 
@@ -554,24 +558,15 @@ public class WorldSchematic extends Level
     }
 
     @Override
-    public float getShade(@Nonnull Direction direction, boolean shaded)
+    public CardinalLighting cardinalLighting()
     {
-	    DimensionType.CardinalLightType cardinalLightType = this.dimensionType().cardinalLightType();
+        return this.dimensionType().cardinalLightType().get();
+    }
 
-        if (!shaded)
-        {
-            return cardinalLightType == DimensionType.CardinalLightType.NETHER ? 0.9F : 1.0F;
-        }
-        else
-        {
-            return switch (direction)
-            {
-	            case DOWN -> cardinalLightType == DimensionType.CardinalLightType.NETHER ? 0.9F : 0.5F;
-	            case UP -> cardinalLightType == DimensionType.CardinalLightType.NETHER ? 0.9F : 1.0F;
-	            case NORTH, SOUTH -> 0.8F;
-	            case WEST, EAST -> 0.6F;
-            };
-        }
+    @Override
+    public int getBlockTint(@Nonnull BlockPos pos, @Nonnull ColorResolver resolver)
+    {
+        return resolver.getColor(this.getBiome(pos).value(), pos.getX(), pos.getZ());
     }
 
     @Override
@@ -665,22 +660,18 @@ public class WorldSchematic extends Level
         }
     }
 
-    @Override
     public void setDayTimeFraction(float f) {
 
     }
 
-    @Override
     public float getDayTimeFraction() {
         return 0;
     }
 
-    @Override
     public float getDayTimePerTick() {
         return 0;
     }
 
-    @Override
     public void setDayTimePerTick(float f) {
 
     }
@@ -739,5 +730,15 @@ public class WorldSchematic extends Level
 	public @Nonnull WorldBorder getWorldBorder()
 	{
 		return new WorldBorder();
+	}
+
+	@Override
+	public @Nonnull ClockManager clockManager()
+	{
+		if (this.mc != null && this.mc.level != null)
+		{
+			return this.mc.level.clockManager();
+		}
+		return clock -> 0L;
 	}
 }

--- a/src/main/resources/litematica.accesswidener
+++ b/src/main/resources/litematica.accesswidener
@@ -1,2 +1,1 @@
-accessWidener v2 named
-accessible field net/minecraft/client/renderer/block/BlockModelShaper modelByStateCache Ljava/util/Map;
+accessWidener v2 official


### PR DESCRIPTION
## Port to NeoForge 26.1.2 / MC 26.1.2

Full migration from `neoforge/1.21.11` to NeoForge 26.1.2, which ships with unobfuscated Minecraft sources. Compiles cleanly.

### Build
- Switch `dev.architectury.loom` → `dev.architectury.loom-no-remap` (MC 26.x is unobfuscated, no remapping needed)
- Drop `loom.officialMojangMappings()` (redundant without remap)
- Upgrade Java target 21 → 25; switch to toolchain declaration
- Change `modImplementation` → `implementation` for malilib and conditional-mixin
- Remove `include()` wrapper around conditional-mixin

### Rendering pipeline
- Update `BlockModelRendererSchematic`, `ChunkRendererSchematicVbo`, `WorldRendererSchematic`, and AO processors to the new `BakedQuad` / `QuadInstance` API
- Adapt `IMixinBlockRenderManager`, `MixinBlockRenderDispatcher`, `MixinWorldRenderer`, `MixinGameRenderer` to 26.x render hook signatures
- Fix `ChunkRenderLayers`, `ChunkRenderBatchDraw`, `ChunkRenderWorkerLitematica` for updated render layer handling

### World / chunk
- Replace direct access to `ChunkPos` private fields with public accessors
- Update `ChunkManagerSchematic`, `WorldSchematic`, `SchematicEntityLookup` to 26.x chunk/entity API
- Adapt `BlockAndTintGetter` usages across `ChunkCacheSchematic` and world utilities

### Misc
- Rename `getTags()` to updated tag API throughout util and schematic classes
- Update accesswidener entries for unobfuscated class names
- Adapt scheduler tasks, placement manager, and schematic verifier to changed method signatures

> This branch is not intended to be merged into `neoforge/1.21.11` — each MC version lives on its own branch.
